### PR TITLE
151581 Change Turkey name to "Republic of Türkiye" and "Türkiye"

### DIFF
--- a/frontend-service/src/conf/countriesByGroup.json
+++ b/frontend-service/src/conf/countriesByGroup.json
@@ -156,7 +156,7 @@
       "flag": "CH"
     },
     {
-      "name": "Turkey",
+      "name": "Türkiye",
       "code": "TR",
       "flag": "TR"
     }
@@ -183,7 +183,7 @@
       "flag": "CH"
     },
     {
-      "name": "Turkey",
+      "name": "Türkiye",
       "code": "TR",
       "flag": "TR"
     }


### PR DESCRIPTION
Didn't find any place to use the Republic of variant... @fkouret 