### PR TITLE
Feature 250788 historic release dates ability to change

### DIFF
--- a/common-interfaces/src/main/java/org/eea/interfaces/controller/dataset/DatasetSnapshotController.java
+++ b/common-interfaces/src/main/java/org/eea/interfaces/controller/dataset/DatasetSnapshotController.java
@@ -78,6 +78,16 @@ public interface DatasetSnapshotController {
       @PathVariable("idSnapshot") Long idSnapshot);
 
   /**
+   * Update the release date of a historic release entry.
+   *
+   * @param datasetId the dataset id
+   * @param idSnapshot the snapshot id
+   * @param newReleaseDate the new release date
+   */
+  @PutMapping(value = "/private/{snapshotId}/dataset/{datasetId}/updateReleaseDate", produces = MediaType.APPLICATION_JSON_VALUE)
+  void updateHistoricReleaseDate(@PathVariable("datasetId") Long datasetId,@PathVariable("snapshotId") Long idSnapshot, @RequestParam("newReleaseDate") String newReleaseDate);
+
+  /**
    * Delete snapshot legacy.
    *
    * @param datasetId the dataset id

--- a/common-utitlities/src/main/java/org/eea/exception/EEAErrorMessage.java
+++ b/common-utitlities/src/main/java/org/eea/exception/EEAErrorMessage.java
@@ -712,6 +712,9 @@ public final class EEAErrorMessage {
   public static final String DELETING_SNAPSHOT_DOCUMENT =
       "An unknown error happenned while deleting the snapshot document.";
 
+  /** The Constant SNAPSHOT_NOTFOUND: {@value}. */
+  public static final String SNAPSHOT_NOTFOUND = "Snapshot not found.";
+
   /** The Constant UPDATING_COLLABORATION_DOCUMENT: {@value}. */
   public static final String UPDATING_COLLABORATION_DOCUMENT =
       "An unknown error happenned while uploading a collaboration document.";
@@ -735,6 +738,10 @@ public final class EEAErrorMessage {
   /** The Constant RESTORING_SNAPSHOT: {@value}. */
   public static final String RESTORING_SNAPSHOT =
       "An unknown error happenned while restoring a snapshot.";
+
+  /** The Constant RESTORING_SNAPSHOT: {@value}. */
+  public static final String UPDATING_SNAPSHOT =
+      "An unknown error happenned while attempting to update a snapshot.";
 
   /** The Constant CREATING_USERS_THROUGH_FILE: {@value}. */
   public static final String CREATING_USERS_THROUGH_FILE =

--- a/dataset-service/src/main/java/org/eea/dataset/controller/DatasetSnapshotControllerImpl.java
+++ b/dataset-service/src/main/java/org/eea/dataset/controller/DatasetSnapshotControllerImpl.java
@@ -13,13 +13,11 @@ import org.eea.dataset.service.DatasetSchemaService;
 import org.eea.dataset.service.DatasetSnapshotService;
 import org.eea.dataset.service.DatasetTableService;
 import org.eea.dataset.service.ResolveSnapshotTable;
-import org.eea.dataset.service.impl.DatasetSnapshotServiceImpl;
 import org.eea.exception.EEAErrorMessage;
 import org.eea.exception.EEAException;
 import org.eea.interfaces.controller.communication.NotificationController.NotificationControllerZuul;
 import org.eea.interfaces.controller.dataflow.DataFlowController.DataFlowControllerZuul;
 import org.eea.interfaces.controller.dataset.DatasetMetabaseController.DataSetMetabaseControllerZuul;
-import org.eea.interfaces.controller.dataset.DatasetSchemaController;
 import org.eea.interfaces.controller.dataset.DatasetSnapshotController;
 import org.eea.interfaces.controller.orchestrator.JobController.JobControllerZuul;
 import org.eea.interfaces.controller.recordstore.ProcessController.ProcessControllerZuul;
@@ -721,6 +719,54 @@ public class DatasetSnapshotControllerImpl implements DatasetSnapshotController 
   }
 
   /**
+   * Update the release date of a historic release entry.
+   *
+   * @param datasetId the dataset id
+   * @param idSnapshot the snapshot id
+   * @param newReleaseDate the new release date
+   */
+  @Override
+  @HystrixCommand
+  @PutMapping(value = "/v1/{snapshotId}/dataset/{datasetId}/updateReleaseDate", produces = MediaType.APPLICATION_JSON_VALUE)
+  @PreAuthorize("secondLevelAuthorizeWithApiKey(#datasetId,'DATASET_CUSTODIAN','DATASET_STEWARD','EUDATASET_CUSTODIAN','TESTDATASET_CUSTODIAN','DATACOLLECTION_CUSTODIAN','DATACOLLECTION_STEWARD','REFERENCEDATASET_CUSTODIAN','REFERENCEDATASET_STEWARD','DATASCHEMA_CUSTODIAN','DATASCHEMA_STEWARD') OR hasAnyRole('ADMIN')")
+  @ApiOperation(value = "Update release date of a historic release entry", hidden = true,
+      notes = "Allowed roles: \n\n Reporting dataset: CUSTODIAN, STEWARD"
+          + "\n\n Data collection: CUSTODIAN, STEWARD"
+          + "\n\n EU dataset: CUSTODIAN, STEWARD")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Successfully updated release date"),
+      @ApiResponse(code = 400, message = "Dataset id incorrect or user request not found")})
+  public void updateHistoricReleaseDate(
+      @ApiParam(type = "Long", value = "Dataset id", example = "0")
+      @PathVariable("datasetId") Long datasetId,
+      @ApiParam(type = "Long", value = "Snapshot id", example = "0")
+      @PathVariable("snapshotId") Long idSnapshot,
+      @ApiParam(type = "String",
+          value = "New Release Date") @RequestParam("newReleaseDate") String newReleaseDate) {
+
+    if (datasetId == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, EEAErrorMessage.DATASET_INCORRECT_ID);
+    }
+
+    try {
+      LOG.info("Updating historic release date for snapshotId {} and datasetId {} to {}",
+          idSnapshot, datasetId, newReleaseDate);
+      datasetSnapshotService.updateHistoricReleaseDate(datasetId, idSnapshot, newReleaseDate);
+      LOG.info("Successfully updated historic release date for snapshotId {} and datasetId {}",
+          idSnapshot, datasetId);
+    } catch (EEAException e) {
+      LOG.error("Error updating historic release date for snapshotId {} and datasetId {}. Error: {}",
+          idSnapshot, datasetId, e.getMessage(), e);
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+          EEAErrorMessage.EXECUTION_ERROR);
+    } catch (Exception e) {
+      LOG.error("Unexpected error! Error updating historic release date for snapshotId {} and datasetId {}. Message: {}",
+          idSnapshot, datasetId, e.getMessage());
+      throw e;
+    }
+  }
+
+  /**
    * Historic releases legacy.
    *
    * @param datasetId the dataset id
@@ -1160,4 +1206,5 @@ public class DatasetSnapshotControllerImpl implements DatasetSnapshotController 
   public void rollBackSnapshotRecord(@PathVariable Long jobId, @RequestParam("dataflowId") Long dataflowId, @RequestParam("providerId") Long providerId) {
     resolveSnapshotTable.rollBackSnapshotTableValues(jobId, dataflowId, providerId);
   }
+
 }

--- a/dataset-service/src/main/java/org/eea/dataset/service/DatasetSnapshotService.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/DatasetSnapshotService.java
@@ -331,4 +331,13 @@ public interface DatasetSnapshotService {
    * @throws IOException Signals that an I/O exception has occurred.
    */
   File downloadHistoricReleasesCSV(Long datasetId, String fileName) throws IOException;
+
+  /**
+   * Update historic release date.
+   *
+   * @param datasetId the dataset id
+   * @param snapshotId the snapshot id
+   * @throws EEAException the EEA exception
+   */
+  void updateHistoricReleaseDate(Long datasetId, Long snapshotId, String newReleaseDate) throws EEAException;
 }

--- a/dataset-service/src/main/java/org/eea/dataset/service/impl/DatasetSnapshotServiceImpl.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/impl/DatasetSnapshotServiceImpl.java
@@ -104,14 +104,7 @@ import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.eea.utils.LiteralConstants.*;
@@ -1730,5 +1723,77 @@ public class DatasetSnapshotServiceImpl implements DatasetSnapshotService {
     }
 
     return file;
+  }
+
+  @Override
+  public void updateHistoricReleaseDate(Long datasetId, Long snapshotId, String newReleaseDate) throws EEAException {
+    if (datasetId == null || snapshotId == null || newReleaseDate == null) {
+      throw new EEAException(EEAErrorMessage.DATASET_NOTFOUND);
+    }
+
+    Snapshot snapshot = snapshotRepository.findById(snapshotId).orElse(null);
+    if (snapshot == null) {
+      throw new EEAException(EEAErrorMessage.SNAPSHOT_NOTFOUND);
+    }
+
+    // figure out the dataset type we are editing for
+    DataSetMetabaseVO datasetMetabase = datasetMetabaseService.findDatasetMetabase(datasetId);
+    if (datasetMetabase == null) {
+      throw new EEAException(EEAErrorMessage.DATASET_NOTFOUND);
+    }
+
+    DatasetTypeEnum datasetType = datasetMetabase.getDatasetTypeEnum();
+    boolean belongsToDataset = false;
+
+    switch (datasetType) {
+      case REPORTING:
+        belongsToDataset =snapshot.getReportingDataset() != null && Objects.equals(snapshot.getReportingDataset().getId(), datasetId);
+        break;
+      case COLLECTION:
+        belongsToDataset = Objects.equals(snapshot.getDataCollectionId(), datasetId);
+        break;
+      case EUDATASET:
+        EUDataset eudataset = eUDatasetRepository.findById(datasetId).orElse(null);
+        if (eudataset == null) {
+          throw new EEAException(EEAErrorMessage.DATASET_NOTFOUND);
+        }
+        // Get data collection from eu dataset to change the snapshot.
+        DataCollection dataCollection =dataCollectionRepository.findFirstByDatasetSchema(eudataset.getDatasetSchema()).orElse(null);
+        if (dataCollection == null) {
+          throw new EEAException(EEAErrorMessage.DATASET_NOTFOUND);
+        }
+        belongsToDataset = Objects.equals(snapshot.getDataCollectionId(), dataCollection.getId());
+        break;
+      default:
+        throw new EEAException("Unsupported dataset type: " + datasetType);
+    }
+
+    if (!belongsToDataset) {
+      // Protect against someone editing a snapshot of another dataset by mistake
+      throw new EEAException(EEAErrorMessage.DATASET_NOTFOUND);
+    }
+
+    Date dateReleasing = null;
+    // Update date_released field.
+    if (StringUtils.isNotBlank(newReleaseDate)) {
+      try {
+        dateReleasing = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX").parse(newReleaseDate);
+      } catch (ParseException e) {
+        LOG.error("Error parsing the date of the release of snapshot with id {} for datasetId {}. Message: {}", snapshotId, datasetId, e.getMessage());
+        throw new EEAException(EEAErrorMessage.UPDATING_SNAPSHOT);
+      }
+    }
+
+    snapshot.setDateReleased(dateReleasing);
+      // Update description of Releases.
+    if (dateReleasing != null) {
+      SimpleDateFormat descFmt = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+      String formatted = descFmt.format(dateReleasing);
+      snapshot.setDescription("Release " + formatted);
+    }
+
+    snapshotRepository.save(snapshot);
+
+    LOG.info("Updated dateReleased and description for snapshotId {} and datasetId {} to {}", snapshotId, datasetId, newReleaseDate);
   }
 }


### PR DESCRIPTION
New endpoint /v1/{snapshotId}/dataset/{datasetId}/updateReleaseDate that requests a date in format: yyyy-MM-dd'T'HH:mm:ssX
Example request:
```
curl -X PUT \
  "http://localhost:xxxx/snapshot/v1/{snapshotId}/dataset/{datasetId}/updateReleaseDate?newReleaseDate=2025-07-31T18:47:30Z" \
  -H "Authorization: Bearer <your-token>"
```