### PR TITLE
293011 upgrade maven depedencies `drools-core`, `drools-compiler`, `drools-templates`, `kie-api` and `kie-ci` from 7.20.0.Final to 8.44.0.Final

### DIFF
--- a/validation-service/pom.xml
+++ b/validation-service/pom.xml
@@ -9,7 +9,7 @@
 		<relativePath>../parent-poms/microservice</relativePath>
 	</parent>
 	<properties>
-		<droolsVersion>7.20.0.Final</droolsVersion>
+		<droolsVersion>8.44.0.Final</droolsVersion>
 		<sonar.moduleKey>org.eea:reportnet:validation-service:${sonar.jenkins.branch}</sonar.moduleKey>
 	</properties>
 	<artifactId>validation-service</artifactId>


### PR DESCRIPTION
This is the bump up from version 7.20.0.Final to 8.44.0.Final for maven dependencies:
*  `drools-core`
* `drools-compiler`
* `drools-templates`
* `kie-api` 
* `kie-ci`

The path is clear but we need a lot of testing activities on this one. Discrepancies may occur but probably it will be simple code changes and nothing about configuration. It will surly need some time at the Sandbox Environment with various data types testing to show its real functionality.

