### PR TITLE
fix bug for transforming old spatial data sql to dremio sql

### DIFF
--- a/validation-service/src/main/java/org/eea/validation/service/impl/RulesServiceImpl.java
+++ b/validation-service/src/main/java/org/eea/validation/service/impl/RulesServiceImpl.java
@@ -1984,7 +1984,7 @@ public class RulesServiceImpl implements RulesService {
                                          String newDatasetSchemaId, Rule rule, List<IntegritySchema> integrities, Long datasetId, DataFlowVO dataFlowVO) throws EEAException {
 
     // Here we change the fields of the rule involved with the help of the dictionary
-    fillRuleImport(rule, dictionaryOriginTargetObjectId, datasetId, dataFlowVO);
+    fillRuleImport(rule, dictionaryOriginTargetObjectId, newDatasetSchemaId, datasetId, dataFlowVO);
 
     // If the rule is a Dataset type, we need to do the same process with the
     // IntegritySchema
@@ -2010,7 +2010,7 @@ public class RulesServiceImpl implements RulesService {
    * @param dictionaryOriginTargetObjectId the dictionary origin target object id
    */
   private void fillRuleImport(Rule rule,
-                                             Map<String, String> dictionaryOriginTargetObjectId, Long datasetId, DataFlowVO dataFlowVO) {
+                                             Map<String, String> dictionaryOriginTargetObjectId,String newDatasetSchemaId, Long datasetId, DataFlowVO dataFlowVO) {
 
     String newRuleId = new ObjectId().toString();
     dictionaryOriginTargetObjectId.put(rule.getRuleId().toString(), newRuleId);
@@ -2057,7 +2057,7 @@ public class RulesServiceImpl implements RulesService {
         rule.setSqlSentence(newSqlSentence);
         if(BooleanUtils.isTrue(dataFlowVO.getBigData())) {
           try {
-            fixSqlSentence(rule, newObjectId, datasetId);
+            fixSqlSentence(rule, newDatasetSchemaId, datasetId);
           } catch (Exception exception) {
             LOG.error("Error updating isSQLSentence information while importing dataset for rule {}", rule.getRuleId());
           }
@@ -2714,7 +2714,8 @@ public class RulesServiceImpl implements RulesService {
   private String getModifiedSql(Rule rule, String tableName, Long datasetId) {
     if (rule.getSqlSentence().startsWith(SPATIAL_DATA_OLD_AUTOMATIC_QC_RULE_1)) {
       String fromClause = String.format(FROM_CLAUSE_STATEMENT, datasetId, tableName);
-      String fieldName = getFieldName(rule);
+      String fieldName = getFieldNameFromOriginalSql(rule);
+
       return String.format(SPATIAL_DATA_NEW_AUTOMATIC_QC_RULE_SENTENCE, fieldName, fromClause, fieldName ,fieldName);
     }
     return "";
@@ -2736,9 +2737,35 @@ public class RulesServiceImpl implements RulesService {
     }
   }
 
-  private String getFieldName(Rule rule) {
-    int startInd = rule.getSqlSentence().indexOf("\"") +1;
-    int endInd = rule.getSqlSentence().indexOf("_id\"", startInd);
-    return rule.getSqlSentence().substring(startInd, endInd);
+  private String getFieldNameFromOriginalSql(Rule rule) {
+
+    String sql = rule.getSqlSentence();
+    if (sql == null) {
+      return null;
+    }
+
+    // Look for pattern: "fv.id as FIELD_NAME_id"
+    String marker = "fv.id as ";
+    int start = sql.indexOf(marker);
+
+    if (start == -1) {
+      // maybe uppercase
+      marker = "FV.ID AS ";
+      start = sql.indexOf(marker);
+      if (start == -1) {
+        return null; // cannot parse
+      }
+    }
+
+    start += marker.length();
+
+    // find the "_id" ending
+    int end = sql.indexOf("_id", start);
+    if (end == -1) {
+      return null;
+    }
+
+    // Extract: Field name
+    return sql.substring(start, end);
   }
 }


### PR DESCRIPTION
ticket  : https://taskman.eionet.europa.eu/issues/280761
This change will fix both clone and import schema to a big data dataflow converting the old spatial query to new form as mentioned in ticket note 11 

 as per the examples in the ticket the queries will become as follow in the new big data dataset :
08_Geometry_validation_polygons
select record_id, ST_isValidReason(Geometry_polygons) as reason from dataset_1443.ProtectedSite where OCTET_LENGTH(Geometry_polygons) > 0 and ST_isValid(Geometry_polygons) = false

09_Geometry_validation_points
select record_id, ST_isValidReason(Geometry_points) as reason from dataset_1443.ProtectedSite where OCTET_LENGTH(Geometry_points) > 0 and ST_isValid(Geometry_points) = false