### PR TITLE
293011 upgrade maven depedency `postgresql` from 42.6.0 to 42.7.8

### DIFF
--- a/collaboration-service/pom.xml
+++ b/collaboration-service/pom.xml
@@ -24,7 +24,7 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>42.6.0</version>
+			<version>42.7.8</version>
 		</dependency>
 	</dependencies>
 	<distributionManagement>

--- a/common-utitlities/src/main/java/org/eea/multitenancy/TenantResolver.java
+++ b/common-utitlities/src/main/java/org/eea/multitenancy/TenantResolver.java
@@ -27,7 +27,7 @@ public final class TenantResolver extends ThreadPropertiesManager {
    */
   public static String getTenantName() {
     Map<String, Object> properties = thread.get();
-    String datasetName = "";
+    String datasetName = "dataset_0"; // default schema
     if (null != properties && !properties.isEmpty()) {
       Object value = properties.get(LiteralConstants.DATASET_NAME);
       if (null != value && StringUtils.isNotEmpty(value.toString())) {

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -33,7 +33,7 @@
           <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.6.0</version>
+            <version>42.7.8</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/dataflow-service/pom.xml
+++ b/dataflow-service/pom.xml
@@ -24,7 +24,7 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>42.6.0</version>
+			<version>42.7.8</version>
 		</dependency>
 		<dependency>
 			<groupId>com.opencsv</groupId>

--- a/dataset-service/pom.xml
+++ b/dataset-service/pom.xml
@@ -29,7 +29,7 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>42.6.0</version>
+			<version>42.7.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mongodb</groupId>

--- a/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/AttachmentValue.java
+++ b/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/AttachmentValue.java
@@ -23,7 +23,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "ATTACHMENT_VALUE")
+@Table(name = "attachment_value", schema = "dataset_0")
 public class AttachmentValue {
 
 

--- a/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/AttachmentValue.java
+++ b/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/AttachmentValue.java
@@ -23,7 +23,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "attachment_value", schema = "dataset_0")
+@Table(name = "attachment_value")
 public class AttachmentValue {
 
 

--- a/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/DatasetValidation.java
+++ b/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/DatasetValidation.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "DATASET_VALIDATION")
+@Table(name = "dataset_validation", schema = "dataset_0")
 public class DatasetValidation {
 
   /**

--- a/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/DatasetValidation.java
+++ b/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/DatasetValidation.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "dataset_validation", schema = "dataset_0")
+@Table(name = "dataset_validation")
 public class DatasetValidation {
 
   /**

--- a/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/DatasetValue.java
+++ b/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/DatasetValue.java
@@ -23,7 +23,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "DATASET_VALUE")
+@Table(name = "dataset_value", schema = "dataset_0")
 public class DatasetValue {
 
 

--- a/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/DatasetValue.java
+++ b/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/DatasetValue.java
@@ -23,7 +23,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "dataset_value", schema = "dataset_0")
+@Table(name = "dataset_value")
 public class DatasetValue {
 
 

--- a/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/FieldValidation.java
+++ b/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/FieldValidation.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "FIELD_VALIDATION")
+@Table(name = "field_validation", schema = "dataset_0")
 public class FieldValidation {
 
   /**

--- a/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/FieldValidation.java
+++ b/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/FieldValidation.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "field_validation", schema = "dataset_0")
+@Table(name = "field_validation")
 public class FieldValidation {
 
   /**

--- a/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/FieldValue.java
+++ b/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/FieldValue.java
@@ -31,8 +31,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "field_value", schema = "dataset_0")
-
+@Table(name = "field_value")
 public class FieldValue {
 
   /**

--- a/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/FieldValue.java
+++ b/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/FieldValue.java
@@ -31,7 +31,8 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "FIELD_VALUE")
+@Table(name = "field_value", schema = "dataset_0")
+
 public class FieldValue {
 
   /**

--- a/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/RecordValidation.java
+++ b/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/RecordValidation.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "record_validation", schema = "dataset_0")
+@Table(name = "record_validation")
 public class RecordValidation {
 
   /**

--- a/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/RecordValidation.java
+++ b/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/RecordValidation.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "RECORD_VALIDATION")
+@Table(name = "record_validation", schema = "dataset_0")
 public class RecordValidation {
 
   /**

--- a/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/RecordValue.java
+++ b/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/RecordValue.java
@@ -6,7 +6,6 @@ import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -29,8 +28,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "record_value", schema = "dataset_0")
-@BatchSize(size = 1)
+@Table(name = "record_value")
 public class RecordValue {
 
 

--- a/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/RecordValue.java
+++ b/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/RecordValue.java
@@ -16,6 +16,7 @@ import javax.persistence.Transient;
 
 import org.eea.interfaces.vo.dataset.CsvLineAndRecordFieldsHolder;
 import org.eea.interfaces.vo.dataset.enums.ErrorTypeEnum;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.GenericGenerator;
 import lombok.Getter;
 import lombok.Setter;
@@ -28,7 +29,8 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "RECORD_VALUE")
+@Table(name = "record_value", schema = "dataset_0")
+@BatchSize(size = 1)
 public class RecordValue {
 
 
@@ -36,10 +38,12 @@ public class RecordValue {
    * The id.
    */
   @Id
-  @GenericGenerator(name = "record_sequence_generator",
-      strategy = "org.eea.dataset.persistence.data.sequence.RecordValueIdGenerator")
-  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "record_sequence_generator")
-  @Column(name = "ID", columnDefinition = "serial")
+  @GenericGenerator(
+          name = "record_sequence_generator",
+          strategy = "org.eea.dataset.persistence.data.sequence.RecordValueIdGenerator"
+  )
+  @GeneratedValue(generator = "record_sequence_generator")
+  @Column(name = "ID")
   private String id;
 
   /**

--- a/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/TableValidation.java
+++ b/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/TableValidation.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "TABLE_VALIDATION")
+@Table(name = "table_validation", schema = "dataset_0")
 public class TableValidation {
 
   /**

--- a/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/TableValidation.java
+++ b/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/TableValidation.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "table_validation", schema = "dataset_0")
+@Table(name = "table_validation")
 public class TableValidation {
 
   /**

--- a/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/TableValue.java
+++ b/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/TableValue.java
@@ -27,8 +27,7 @@ import org.hibernate.annotations.BatchSize;
 @Getter
 @Setter
 @ToString
-@Table(name = "table_value", schema = "dataset_0")
-@BatchSize(size = 1)
+@Table(name = "table_value")
 public class TableValue {
 
 

--- a/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/TableValue.java
+++ b/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/TableValue.java
@@ -18,6 +18,7 @@ import org.eea.interfaces.vo.dataset.enums.ErrorTypeEnum;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.hibernate.annotations.BatchSize;
 
 /**
  * The Class TableValue.
@@ -26,7 +27,8 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "TABLE_VALUE")
+@Table(name = "table_value", schema = "dataset_0")
+@BatchSize(size = 1)
 public class TableValue {
 
 
@@ -35,10 +37,13 @@ public class TableValue {
    * The id.
    */
   @Id
-  @SequenceGenerator(name = "table_sequence_generator", sequenceName = "table_sequence",
-      allocationSize = 1)
+  @SequenceGenerator(
+          name = "table_sequence_generator",
+          sequenceName = "table_sequence",
+          allocationSize = 1
+  )
   @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "table_sequence_generator")
-  @Column(name = "ID", columnDefinition = "serial")
+  @Column(name = "ID")
   private Long id;
 
   /**

--- a/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/Validation.java
+++ b/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/Validation.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "validation", schema = "dataset_0")
+@Table(name = "validation")
 public class Validation {
 
   /**

--- a/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/Validation.java
+++ b/dataset-service/src/main/java/org/eea/dataset/persistence/data/domain/Validation.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "VALIDATION")
+@Table(name = "validation", schema = "dataset_0")
 public class Validation {
 
   /**

--- a/dataset-service/src/main/java/org/eea/dataset/service/impl/DatasetServiceImpl.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/impl/DatasetServiceImpl.java
@@ -2577,12 +2577,27 @@ public class DatasetServiceImpl implements DatasetService {
         partitionDataSetMetabaseRepository.findFirstByIdDataSet_idAndUsername(datasetId, USER)
             .orElse(new PartitionDataSetMetabase()).getId();
 
-    DatasetValue dataset = new DatasetValue();
-    dataset.setId(datasetId);
+    LOG.info("[CHRIS]");
+    // fetch dataset_value here, if null then save it
+    DatasetValue datasetValue = datasetRepository.findById(datasetId).orElse(null);
+    if (datasetValue == null) {
+      datasetValue = new DatasetValue();
+      datasetValue.setId(datasetId);
+      datasetValue = datasetRepository.save(datasetValue);
+    }
+    LOG.info("[CHRIS] DatasetValue: {}", datasetValue);
 
-    TableValue tableValue = new TableValue();
-    tableValue.setId(tableRepository.findIdByIdTableSchema(tableSchemaId));
-    tableValue.setDatasetId(dataset);
+
+    String schemaId = tableSchema.getIdTableSchema().toString();
+    // fetch table_value here, if null then save it
+    TableValue tableValue = tableRepository.findByIdTableSchema(schemaId);
+    if (tableValue == null) {
+      tableValue = new TableValue();
+      tableValue.setDatasetId(datasetValue);
+      tableValue.setIdTableSchema(schemaId);
+      tableValue = tableRepository.save(tableValue);
+    }
+    LOG.info("[CHRIS] TableValue: {}", tableValue);
 
     List<RecordValue> recordValues = new ArrayList<>();
 

--- a/orchestrator-service/pom.xml
+++ b/orchestrator-service/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.6.0</version>
+      <version>42.7.8</version>
     </dependency>
   </dependencies>
   <distributionManagement>

--- a/recordstore-service/pom.xml
+++ b/recordstore-service/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.6.0</version>
+      <version>42.7.8</version>
     </dependency>
     <dependency>
       <groupId>com.dremio.distribution</groupId>

--- a/validation-service/pom.xml
+++ b/validation-service/pom.xml
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-            <version>42.6.0</version>
+			<version>42.7.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mongodb</groupId>

--- a/validation-service/src/main/java/org/eea/validation/persistence/data/domain/DatasetValidation.java
+++ b/validation-service/src/main/java/org/eea/validation/persistence/data/domain/DatasetValidation.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "dataset_validation", schema = "dataset_0")
+@Table(name = "dataset_validation")
 public class DatasetValidation {
 
   /** The id. */

--- a/validation-service/src/main/java/org/eea/validation/persistence/data/domain/DatasetValidation.java
+++ b/validation-service/src/main/java/org/eea/validation/persistence/data/domain/DatasetValidation.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "DATASET_VALIDATION")
+@Table(name = "dataset_validation", schema = "dataset_0")
 public class DatasetValidation {
 
   /** The id. */

--- a/validation-service/src/main/java/org/eea/validation/persistence/data/domain/DatasetValue.java
+++ b/validation-service/src/main/java/org/eea/validation/persistence/data/domain/DatasetValue.java
@@ -21,7 +21,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "dataset_value", schema = "dataset_0")
+@Table(name = "dataset_value")
 public class DatasetValue {
 
 

--- a/validation-service/src/main/java/org/eea/validation/persistence/data/domain/DatasetValue.java
+++ b/validation-service/src/main/java/org/eea/validation/persistence/data/domain/DatasetValue.java
@@ -21,7 +21,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "DATASET_VALUE")
+@Table(name = "dataset_value", schema = "dataset_0")
 public class DatasetValue {
 
 

--- a/validation-service/src/main/java/org/eea/validation/persistence/data/domain/FieldValidation.java
+++ b/validation-service/src/main/java/org/eea/validation/persistence/data/domain/FieldValidation.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "FIELD_VALIDATION")
+@Table(name = "field_validation", schema = "dataset_0")
 public class FieldValidation {
 
   /**

--- a/validation-service/src/main/java/org/eea/validation/persistence/data/domain/FieldValidation.java
+++ b/validation-service/src/main/java/org/eea/validation/persistence/data/domain/FieldValidation.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "field_validation", schema = "dataset_0")
+@Table(name = "field_validation")
 public class FieldValidation {
 
   /**

--- a/validation-service/src/main/java/org/eea/validation/persistence/data/domain/FieldValue.java
+++ b/validation-service/src/main/java/org/eea/validation/persistence/data/domain/FieldValue.java
@@ -29,7 +29,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "field_value", schema = "dataset_0")
+@Table(name = "field_value")
 public class FieldValue {
 
   /** The id. */

--- a/validation-service/src/main/java/org/eea/validation/persistence/data/domain/FieldValue.java
+++ b/validation-service/src/main/java/org/eea/validation/persistence/data/domain/FieldValue.java
@@ -29,7 +29,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "FIELD_VALUE")
+@Table(name = "field_value", schema = "dataset_0")
 public class FieldValue {
 
   /** The id. */

--- a/validation-service/src/main/java/org/eea/validation/persistence/data/domain/RecordValidation.java
+++ b/validation-service/src/main/java/org/eea/validation/persistence/data/domain/RecordValidation.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "record_validation", schema = "dataset_0")
+@Table(name = "record_validation")
 public class RecordValidation {
 
   /**

--- a/validation-service/src/main/java/org/eea/validation/persistence/data/domain/RecordValidation.java
+++ b/validation-service/src/main/java/org/eea/validation/persistence/data/domain/RecordValidation.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "RECORD_VALIDATION")
+@Table(name = "record_validation", schema = "dataset_0")
 public class RecordValidation {
 
   /**

--- a/validation-service/src/main/java/org/eea/validation/persistence/data/domain/RecordValue.java
+++ b/validation-service/src/main/java/org/eea/validation/persistence/data/domain/RecordValue.java
@@ -24,7 +24,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "RECORD_VALUE")
+@Table(name = "record_value", schema = "dataset_0")
 public class RecordValue {
 
   /** The id. */

--- a/validation-service/src/main/java/org/eea/validation/persistence/data/domain/RecordValue.java
+++ b/validation-service/src/main/java/org/eea/validation/persistence/data/domain/RecordValue.java
@@ -24,7 +24,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "record_value", schema = "dataset_0")
+@Table(name = "record_value")
 public class RecordValue {
 
   /** The id. */

--- a/validation-service/src/main/java/org/eea/validation/persistence/data/domain/TableValidation.java
+++ b/validation-service/src/main/java/org/eea/validation/persistence/data/domain/TableValidation.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "TABLE_VALIDATION")
+@Table(name = "table_validation", schema = "dataset_0")
 public class TableValidation {
 
   /**

--- a/validation-service/src/main/java/org/eea/validation/persistence/data/domain/TableValidation.java
+++ b/validation-service/src/main/java/org/eea/validation/persistence/data/domain/TableValidation.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "table_validation", schema = "dataset_0")
+@Table(name = "table_validation")
 public class TableValidation {
 
   /**

--- a/validation-service/src/main/java/org/eea/validation/persistence/data/domain/TableValue.java
+++ b/validation-service/src/main/java/org/eea/validation/persistence/data/domain/TableValue.java
@@ -26,7 +26,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "table_value", schema = "dataset_0")
+@Table(name = "table_value")
 public class TableValue {
 
   /**

--- a/validation-service/src/main/java/org/eea/validation/persistence/data/domain/TableValue.java
+++ b/validation-service/src/main/java/org/eea/validation/persistence/data/domain/TableValue.java
@@ -26,7 +26,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "TABLE_VALUE")
+@Table(name = "table_value", schema = "dataset_0")
 public class TableValue {
 
   /**

--- a/validation-service/src/main/java/org/eea/validation/persistence/data/domain/Validation.java
+++ b/validation-service/src/main/java/org/eea/validation/persistence/data/domain/Validation.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "validation", schema = "dataset_0")
+@Table(name = "validation")
 public class Validation {
 
   /**

--- a/validation-service/src/main/java/org/eea/validation/persistence/data/domain/Validation.java
+++ b/validation-service/src/main/java/org/eea/validation/persistence/data/domain/Validation.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@Table(name = "VALIDATION")
+@Table(name = "validation", schema = "dataset_0")
 public class Validation {
 
   /**


### PR DESCRIPTION
This is the bump up from version `42.6.0` to `42.7.8` for maven dependency `postgresql`.

There are active issues that put the whole project at risk, because there is a more strict handling of resolving tenants, entities have to assign a default schema and also it enforces the actual foreign-key rules defined in the database to save an object, you cannot just save a child with assigned parent if parent is a new object and not already existing to database.

Next changes should abort this default schema, mutate the tenant resolver classes and have extra configuration about tenants if needed. This is a complex task and hard to test across platform.