### PR TITLE
Bug#294147 webform tab title transparent sandbox

### DIFF
--- a/frontend-service/src/views/Webforms/_components/WebformTable/WebformTable.module.scss
+++ b/frontend-service/src/views/Webforms/_components/WebformTable/WebformTable.module.scss
@@ -47,7 +47,8 @@
     position: fixed;
     top: 64px;
     z-index: 100;
-    background-color: rgba(255, 255, 255, 1);
+    // background-color: rgba(255, 255, 255, 1);
+    background-color: var(--bg);
     width:90vw;
   }
 

--- a/frontend-service/src/views/Webforms/_components/WebformTable/WebformTable.module.scss
+++ b/frontend-service/src/views/Webforms/_components/WebformTable/WebformTable.module.scss
@@ -47,7 +47,6 @@
     position: fixed;
     top: 64px;
     z-index: 100;
-    // background-color: rgba(255, 255, 255, 1);
     background-color: var(--bg);
     width:90vw;
   }


### PR DESCRIPTION
Fix for dark mode. The webform tab title is now transparent.