### PR TITLE
remove calls from dataflowmetabase, keep schemas in memory,

### DIFF
--- a/dataset-service/src/main/java/org/eea/dataset/controller/DataCollectionControllerImpl.java
+++ b/dataset-service/src/main/java/org/eea/dataset/controller/DataCollectionControllerImpl.java
@@ -146,6 +146,10 @@ public class DataCollectionControllerImpl implements DataCollectionController {
     Long dataflowId = dataCollectionVO.getIdDataflow();
     // new check: dataflow is Reference dataset?
     DataFlowVO dataflow = dataCollectionService.getDataflowMetabase(dataflowId);
+    boolean isBigDataflow = (dataflow != null)
+            ? Boolean.TRUE.equals(dataflow.getBigData())
+            : Boolean.FALSE;
+
     boolean referenceDataflow = false;
     if (null != dataflow && TypeDataflowEnum.REFERENCE.equals(dataflow.getType())) {
       referenceDataflow = true;
@@ -181,7 +185,7 @@ public class DataCollectionControllerImpl implements DataCollectionController {
       // This method will release the lock
        LOG.info("Creating empty data collection for dataflowId {}", dataflowId);
       dataCollectionService.createEmptyDataCollection(dataflowId, date, stopAndNotifySQLErrors,
-              manualCheck, showPublicInfo, referenceDataflow, stopAndNotifyPKError);
+              manualCheck, showPublicInfo, referenceDataflow, stopAndNotifyPKError, isBigDataflow);
       LOG.info("DataCollection creation for Dataflow {} started", dataflowId);
     } catch (Exception e) {
 

--- a/dataset-service/src/main/java/org/eea/dataset/service/DataCollectionService.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/DataCollectionService.java
@@ -49,7 +49,7 @@ public interface DataCollectionService {
    */
   void createEmptyDataCollection(Long dataflowId, LocalDateTime dueDate,
       boolean stopAndNotifySQLErrors, boolean manualCheck, boolean showPublicInfo,
-      boolean referenceDataflow, boolean stopAndNotifyPKError);
+      boolean referenceDataflow, boolean stopAndNotifyPKError, boolean isBigDataflow);
 
   /**
    * Adds the foreign relations from new reportings.

--- a/dataset-service/src/main/java/org/eea/dataset/service/DatasetSchemaService.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/DatasetSchemaService.java
@@ -637,4 +637,6 @@ public interface DatasetSchemaService {
    * @throws EEAException
    */
   void validateTableFieldNameHasNoWhitespace(String fieldName) throws EEAException;
+
+  boolean isReferenceSchema(String datasetSchemaId);
 }

--- a/dataset-service/src/main/java/org/eea/dataset/service/impl/DataCollectionServiceImpl.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/impl/DataCollectionServiceImpl.java
@@ -407,9 +407,8 @@ public class DataCollectionServiceImpl implements DataCollectionService {
   @Async
   public void createEmptyDataCollection(Long dataflowId, LocalDateTime dueDate,
       boolean stopAndNotifySQLErrors, boolean manualCheck, boolean showPublicInfo,
-      boolean referenceDataflow, boolean stopAndNotifyPKError) {
+      boolean referenceDataflow, boolean stopAndNotifyPKError, boolean isBigDataflow) {
 
-    Boolean isBigDataflow = dataflowControllerZuul.isBigDataflow(dataflowId);
     List<DataSetMetabaseVO> datasets = datasetMetabaseService.findDataSetByDataflowIds(Collections.singletonList(dataflowId));
 
     if(Boolean.TRUE.equals(isBigDataflow)){
@@ -493,11 +492,13 @@ public class DataCollectionServiceImpl implements DataCollectionService {
    */
   private void manageDataCollection(Long dataflowId, LocalDateTime dueDate, boolean isCreation,
       boolean stopAndNotifySQLErrors, boolean manualCheck, boolean referenceDataflow,
-      boolean stopAndNotifyPKError, Boolean isBigDataflow) {
+      boolean stopAndNotifyPKError, boolean isBigDataflow) {
     String time = Timestamp.valueOf(LocalDateTime.now()).toString();
 
     boolean rulesOk = true;
     boolean hasPk = true;
+    // Cache reference-schema checks per DC execution
+    Map<String, Boolean> isReferenceSchemaBySchemaId = new HashMap<>();
 
     // 1. Get the design datasets
     List<DesignDatasetVO> designs = designDatasetService.getDesignDataSetIdByDataflowId(dataflowId);
@@ -519,14 +520,19 @@ public class DataCollectionServiceImpl implements DataCollectionService {
       LOG.info("Validate SQL Rules for dataflowId {}, Data Collection creation process.", dataflowId);
       List<Boolean> rulesWithError = new ArrayList<>();
       List<Long> emptyDatasetTables = new ArrayList<>();
-      designs.stream().forEach(dataset -> {
 
+      designs.stream().forEach(dataset -> {
         //we will update the materialized views only once and only for not reference datasets
-        if(stopAndNotifySQLErrors) {
-          DataSetSchemaVO schema = datasetSchemaService.getDataSchemaById(dataset.getDatasetSchema());
-          if (schema != null && schema.getReferenceDataset() != null
-                  && Boolean.TRUE.equals(schema.getReferenceDataset())) {
-            LOG.info("Will not create or update materialized views for reference dataset with id {}", dataset.getId());
+        //we skip materialized views for big data dataflows
+        if(stopAndNotifySQLErrors  && !isBigDataflow) {
+          boolean isReferenceSchema =
+                  isReferenceSchemaBySchemaId.computeIfAbsent(
+                          dataset.getDatasetSchema(),
+                          id -> datasetSchemaService.isReferenceSchema(id)
+                  );
+
+          if (isReferenceSchema) {
+            LOG.info("Will not create or update materialized views...");
           }
           else{
             recordStoreControllerZuul.createUpdateQueryView(dataset.getId(), false);
@@ -539,8 +545,7 @@ public class DataCollectionServiceImpl implements DataCollectionService {
           rulesSql.stream().forEach(ruleVO -> rulesWithError.add(rulesControllerZuul
               .validateSqlRuleDataCollection(dataset.getId(), dataset.getDatasetSchema(), ruleVO)));
 
-          DataFlowVO dataFlowVO = dataflowControllerZuul.getMetabaseById(dataflowId);
-          if (dataFlowVO!=null && BooleanUtils.isTrue(dataFlowVO.getBigData())) {
+          if (isBigDataflow) {
             rulesSql.stream().forEach(ruleVO -> {
               checkIfTablesEmpty(emptyDatasetTables, dataset, ruleVO);
             });
@@ -559,9 +564,11 @@ public class DataCollectionServiceImpl implements DataCollectionService {
     List<DesignDatasetVO> referenceDatasets = new ArrayList<>();
     List<String> referenceSchemasId = new ArrayList<>();
     designs.stream().forEach(dataset -> {
-      DataSetSchemaVO schema = datasetSchemaService.getDataSchemaById(dataset.getDatasetSchema());
-      if (schema != null && schema.getReferenceDataset() != null
-          && Boolean.TRUE.equals(schema.getReferenceDataset())) {
+      boolean isReferenceSchema = isReferenceSchemaBySchemaId.computeIfAbsent(
+                      dataset.getDatasetSchema(),
+                      id -> datasetSchemaService.isReferenceSchema(id)
+              );
+      if (isReferenceSchema) {
         referenceDatasets.add(dataset);
         referenceSchemasId.add(dataset.getDatasetSchema());
         if (isCreation) {
@@ -782,7 +789,7 @@ public class DataCollectionServiceImpl implements DataCollectionService {
       Map<Long, String> map, List<Long> dataCollectionIds, Map<Long, List<String>> datasetIdsEmails,
       Map<Long, List<String>> referenceDatasetIdsEmails, Map<Long, String> datasetIdsAndSchemaIds,
       List<Long> euDatasetIds, Connection connection, Statement statement,
-      boolean referenceDataflow, Boolean isBigData) throws SQLException {
+      boolean referenceDataflow, boolean isBigDataflow) throws SQLException {
     try {
       connection.setAutoCommit(false);
 
@@ -834,7 +841,6 @@ public class DataCollectionServiceImpl implements DataCollectionService {
             testDatasetIds.add(testDatasetId);
             datasetIdsAndSchemaIds.put(testDatasetId, design.getDatasetSchema());
 
-            Boolean isBigDataflow = dataflowControllerZuul.isBigDataflow(dataflowId);
             if(Boolean.TRUE.equals(isBigDataflow)){
               //create prefilled tables for test dataset if needed
               bigDataDatasetService.createPrefilledTables(design.getId(), design.getDatasetSchema(), testDatasetId, 0L, null);
@@ -916,9 +922,9 @@ public class DataCollectionServiceImpl implements DataCollectionService {
         });
       }
 
-
       createPermissions(datasetIdsEmails, referenceDatasetIdsEmails, dataCollectionIds,
           euDatasetIds, testDatasetIds, referenceDatasetIds, dataflowId, isCreation);
+
       // 9. Delete editors
       removePermissionEditors(dataflowId);
 
@@ -938,7 +944,7 @@ public class DataCollectionServiceImpl implements DataCollectionService {
       // 10. Create schemas for each dataset
       // If this is not a big dataflow create schemas as normally
       // otherwise skip schema creation and release locks
-      if (Boolean.FALSE.equals(isBigData)) {
+      if (Boolean.FALSE.equals(isBigDataflow)) {
           recordStoreControllerZuul.createSchemas(datasetIdsAndSchemaIds, dataflowId, isCreation, true);
       }
       else {

--- a/dataset-service/src/main/java/org/eea/dataset/service/impl/DataschemaServiceImpl.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/impl/DataschemaServiceImpl.java
@@ -85,7 +85,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.Future;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * The Class DataschemaServiceImpl.
@@ -3702,6 +3701,12 @@ public class DataschemaServiceImpl implements DatasetSchemaService {
     if (fieldName != null && fieldName.chars().anyMatch(Character::isWhitespace)) {
       throw new EEAException(EEAErrorMessage.FIELD_NAME_WHITESPACES);
     }
+  }
+
+  @Override
+  public boolean isReferenceSchema(String datasetSchemaId){
+    DataSetSchemaVO schema = getDataSchemaById(datasetSchemaId);
+    return schema != null && Boolean.TRUE.equals(schema.getReferenceDataset());
   }
 
 }

--- a/dataset-service/src/test/java/org/eea/dataset/controller/DataCollectionControllerImplTest.java
+++ b/dataset-service/src/test/java/org/eea/dataset/controller/DataCollectionControllerImplTest.java
@@ -135,17 +135,18 @@ public class DataCollectionControllerImplTest {
     Mockito.when(authentication.getName()).thenReturn("user");
     DataFlowVO dataflow = new DataFlowVO();
     dataflow.setStatus(TypeStatusEnum.DESIGN);
+    dataflow.setBigData(Boolean.FALSE);
     Mockito.when(dataCollectionService.getDataflowMetabase(Mockito.any())).thenReturn(dataflow);
     Mockito.doNothing().when(dataCollectionService).createEmptyDataCollection(Mockito.any(),
         Mockito.any(), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean(),
-        Mockito.anyBoolean(), Mockito.anyBoolean());
+        Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean());
     DataCollectionVO dc = new DataCollectionVO();
     dc.setIdDataflow(1L);
     dc.setDueDate(new Date(System.currentTimeMillis() + 100000));
     dataCollectionControllerImpl.createEmptyDataCollection(false, false, false, dc, true);
     Mockito.verify(dataCollectionService, times(1)).createEmptyDataCollection(Mockito.any(),
         Mockito.any(), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean(),
-        Mockito.anyBoolean(), Mockito.anyBoolean());
+        Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean());
   }
 
   /**
@@ -161,38 +162,41 @@ public class DataCollectionControllerImplTest {
     DataFlowVO dataflow = new DataFlowVO();
     dataflow.setStatus(TypeStatusEnum.DESIGN);
     dataflow.setType(TypeDataflowEnum.REFERENCE);
+    dataflow.setBigData(Boolean.FALSE);
     Mockito.when(dataCollectionService.getDataflowMetabase(Mockito.any())).thenReturn(dataflow);
     Mockito.doNothing().when(dataCollectionService).createEmptyDataCollection(Mockito.any(),
         Mockito.any(), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean(),
-        Mockito.anyBoolean(), Mockito.anyBoolean());
+        Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean());
     DataCollectionVO dc = new DataCollectionVO();
     dc.setIdDataflow(1L);
     dc.setDueDate(new Date(System.currentTimeMillis() + 100000));
     dataCollectionControllerImpl.createEmptyDataCollection(false, false, false, dc, true);
     Mockito.verify(dataCollectionService, times(1)).createEmptyDataCollection(Mockito.any(),
         Mockito.any(), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean(),
-        Mockito.anyBoolean(), Mockito.anyBoolean());
+        Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean());
   }
 
   /**
    * Creates the empty data collection type dataflow null test.
    */
-  @Test(expected = ResponseStatusException.class)
+  @Test
   public void createEmptyDataCollectionTypeDataflowNullTest() {
     Mockito.doNothing().when(notificationControllerZuul)
-        .createUserNotificationPrivate(Mockito.anyString(), Mockito.any());
+            .createUserNotificationPrivate(Mockito.anyString(), Mockito.any());
 
-    Mockito.when(dataCollectionService.getDataflowMetabase(Mockito.any())).thenReturn(null);
+    Mockito.when(dataCollectionService.getDataflowMetabase(Mockito.any()))
+            .thenReturn(null);
 
     DataCollectionVO dc = new DataCollectionVO();
     dc.setIdDataflow(1L);
     dc.setDueDate(new Date(System.currentTimeMillis() + 100000));
+
     try {
       dataCollectionControllerImpl.createEmptyDataCollection(false, false, false, dc, true);
+      Assert.fail("Expected ResponseStatusException");
     } catch (ResponseStatusException e) {
       Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatus());
       Assert.assertEquals(EEAErrorMessage.NOT_DESIGN_DATAFLOW, e.getReason());
-      throw e;
     }
   }
 
@@ -209,17 +213,18 @@ public class DataCollectionControllerImplTest {
     DataFlowVO dataflow = new DataFlowVO();
     dataflow.setStatus(TypeStatusEnum.DESIGN);
     dataflow.setType(TypeDataflowEnum.REFERENCE);
+    dataflow.setBigData(Boolean.FALSE);
     Mockito.when(dataCollectionService.getDataflowMetabase(Mockito.any())).thenReturn(dataflow);
     Mockito.doNothing().when(dataCollectionService).createEmptyDataCollection(Mockito.any(),
         Mockito.any(), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean(),
-        Mockito.anyBoolean(), Mockito.anyBoolean());
+        Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean());
     DataCollectionVO dc = new DataCollectionVO();
     dc.setIdDataflow(1L);
     dc.setDueDate(null);
     dataCollectionControllerImpl.createEmptyDataCollection(false, false, false, dc, true);
     Mockito.verify(dataCollectionService, times(1)).createEmptyDataCollection(Mockito.any(),
         Mockito.any(), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean(),
-        Mockito.anyBoolean(), Mockito.anyBoolean());
+        Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean());
   }
 
   /**
@@ -255,6 +260,8 @@ public class DataCollectionControllerImplTest {
 
     DataFlowVO dataflow = new DataFlowVO();
     dataflow.setStatus(TypeStatusEnum.DESIGN);
+    dataflow.setBigData(Boolean.FALSE);
+
     Mockito.when(dataCollectionService.getDataflowMetabase(Mockito.any())).thenReturn(dataflow);
 
     DataCollectionVO dc = new DataCollectionVO();

--- a/dataset-service/src/test/java/org/eea/dataset/service/impl/DataCollectionServiceImplTest.java
+++ b/dataset-service/src/test/java/org/eea/dataset/service/impl/DataCollectionServiceImplTest.java
@@ -347,8 +347,7 @@ public class DataCollectionServiceImplTest {
             .thenReturn(new ArrayList<>());
     Mockito.when(securityContext.getAuthentication()).thenReturn(authentication);
     Mockito.when(authentication.getName()).thenReturn("name");
-    Mockito.when(datasetSchemaService.getDataSchemaById(Mockito.anyString()))
-            .thenReturn(new DataSetSchemaVO());
+
     dataCollectionService.updateDataCollection(1L, false);
     Mockito.verify(connection, times(1)).rollback();
   }
@@ -424,8 +423,6 @@ public class DataCollectionServiceImplTest {
         Mockito.anyBoolean(), Mockito.anyBoolean());
     Mockito.when(datasetSchemaService.getReferencedFieldsBySchema(any()))
         .thenReturn(new ArrayList<>());
-    Mockito.when(datasetSchemaService.getDataSchemaById(Mockito.anyString()))
-        .thenReturn(new DataSetSchemaVO());
     Mockito.when(datasetMetabaseService.getDatasetType(any()))
         .thenReturn(DatasetTypeEnum.REPORTING).thenReturn(DatasetTypeEnum.COLLECTION)
         .thenReturn(DatasetTypeEnum.EUDATASET).thenReturn(DatasetTypeEnum.TEST);
@@ -441,7 +438,7 @@ public class DataCollectionServiceImplTest {
     Mockito.when(authentication.getName()).thenReturn("name");
 
     dataCollectionService.createEmptyDataCollection(1L, LocalDateTime.now(), true, false, false,
-        false, true);
+        false, true, false);
     Mockito.verify(recordStoreControllerZuul, times(1)).createSchemas(any(), any(),
         Mockito.anyBoolean(), Mockito.anyBoolean());
   }
@@ -528,13 +525,11 @@ public class DataCollectionServiceImplTest {
     tableSchema.setRecordSchema(recordSchema);
     schema.setTableSchemas(Arrays.asList(tableSchema));
     schema2.setTableSchemas(Arrays.asList(tableSchema));
-    Mockito.when(datasetSchemaService.getDataSchemaById(Mockito.anyString())).thenReturn(schema)
-        .thenReturn(schema2);
 
     Mockito.when(securityContext.getAuthentication()).thenReturn(authentication);
     Mockito.when(authentication.getName()).thenReturn("name");
     dataCollectionService.createEmptyDataCollection(1L, LocalDateTime.now(), false, false, false,
-        false, true);
+        false, true, false);
     Mockito.verify(recordStoreControllerZuul, times(1)).createSchemas(any(), any(),
         Mockito.anyBoolean(), Mockito.anyBoolean());
   }
@@ -555,10 +550,9 @@ public class DataCollectionServiceImplTest {
         .thenReturn(designs);
     Mockito.when(securityContext.getAuthentication()).thenReturn(authentication);
     Mockito.when(authentication.getName()).thenReturn("name");
-    Mockito.when(datasetSchemaService.getDataSchemaById(Mockito.anyString()))
-        .thenReturn(new DataSetSchemaVO());
+
     dataCollectionService.createEmptyDataCollection(1L, LocalDateTime.now(), true, false, false,
-        false, true);
+        false, true, false);
     Mockito.verify(lockService, times(1)).removeLockByCriteria(any());
   }
 
@@ -574,7 +568,7 @@ public class DataCollectionServiceImplTest {
     Mockito.when(securityContext.getAuthentication()).thenReturn(authentication);
     Mockito.when(authentication.getName()).thenReturn("name");
     dataCollectionService.createEmptyDataCollection(1L, LocalDateTime.now(), true, false, false,
-        false, true);
+        false, true, false);
     Mockito.verify(lockService, times(1)).removeLockByCriteria(any());
   }
 
@@ -611,10 +605,8 @@ public class DataCollectionServiceImplTest {
     Mockito.doNothing().when(connection).rollback();
     Mockito.when(securityContext.getAuthentication()).thenReturn(authentication);
     Mockito.when(authentication.getName()).thenReturn("name");
-    Mockito.when(datasetSchemaService.getDataSchemaById(Mockito.anyString()))
-        .thenReturn(new DataSetSchemaVO());
     dataCollectionService.createEmptyDataCollection(1L, LocalDateTime.now(), true, false, false,
-        false, true);
+        false, true, false);
     Mockito.verify(connection, times(1)).rollback();
   }
 
@@ -664,10 +656,8 @@ public class DataCollectionServiceImplTest {
         .thenReturn(new ArrayList<>());
     Mockito.when(securityContext.getAuthentication()).thenReturn(authentication);
     Mockito.when(authentication.getName()).thenReturn("name");
-    Mockito.when(datasetSchemaService.getDataSchemaById(Mockito.anyString()))
-        .thenReturn(new DataSetSchemaVO());
     dataCollectionService.createEmptyDataCollection(1L, LocalDateTime.now(), true, false, false,
-        false, true);
+        false, true, false);
     Mockito.verify(connection, times(1)).rollback();
   }
 


### PR DESCRIPTION
added isBigdataflow Flag to pass through methosds reducing zuul calls, less datasetschema calls through in memory map,
createUpdateQueryView early checks for big data dataflow 