### PR TITLE
Task #292820 Downloading data as an observer role

### DIFF
--- a/dataset-service/src/main/java/org/eea/dataset/controller/DatasetSchemaControllerImpl.java
+++ b/dataset-service/src/main/java/org/eea/dataset/controller/DatasetSchemaControllerImpl.java
@@ -135,7 +135,8 @@ public class DatasetSchemaControllerImpl implements DatasetSchemaController {
   @Override
   @HystrixCommand
   @PostMapping(value = "/createEmptyDatasetSchema")
-  @PreAuthorize("(secondLevelAuthorize(#dataflowId,'DATAFLOW_CUSTODIAN','DATAFLOW_STEWARD','DATAFLOW_EDITOR_WRITE'))")
+  @PreAuthorize("(secondLevelAuthorize(#dataflowId,T(org.eea.dataset.security.EndpointAuthorization)" +
+          ".getRequiredRightsForEndpoint(\"/dataschema/createEmptyDatasetSchema\")))")
   @ApiOperation(value = "Create empty Dataset Schema", hidden = true)
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Successfully create"),
           @ApiResponse(code = 400, message = EEAErrorMessage.DATASET_NAME_DUPLICATED),
@@ -1381,7 +1382,8 @@ public class DatasetSchemaControllerImpl implements DatasetSchemaController {
    * @return the simple schema
    */
   @Override
-  @PreAuthorize("checkApiKey(#dataflowId,#providerId,#datasetId,'DATASET_STEWARD','DATASET_CUSTODIAN','DATASET_LEAD_REPORTER','DATASET_REPORTER_WRITE','DATASET_REPORTER_READ','DATASCHEMA_CUSTODIAN','DATASCHEMA_STEWARD','DATASCHEMA_EDITOR_WRITE','EUDATASET_CUSTODIAN','EUDATASET_STEWARD','DATACOLLECTION_CUSTODIAN','DATACOLLECTION_STEWARD','DATASET_NATIONAL_COORDINATOR','TESTDATASET_CUSTODIAN','TESTDATASET_STEWARD_SUPPORT','TESTDATASET_STEWARD','REFERENCEDATASET_CUSTODIAN','REFERENCEDATASET_LEAD_REPORTER','REFERENCEDATASET_STEWARD')")
+  @PreAuthorize("checkApiKey(#dataflowId,#providerId,#datasetId,T(org.eea.dataset.security.EndpointAuthorization)" +
+          ".getRequiredRightsForEndpoint(\"/dataschema/v1/getSimpleSchema/dataset/{datasetId}\"))")
   @GetMapping(value = "/v1/getSimpleSchema/dataset/{datasetId}",
           produces = MediaType.APPLICATION_JSON_VALUE)
   @ApiOperation(value = "Get dataset schema by dataset id",
@@ -1423,7 +1425,8 @@ public class DatasetSchemaControllerImpl implements DatasetSchemaController {
    * @return the simple schema legacy
    */
   @Override
-  @PreAuthorize("checkApiKey(#dataflowId,#providerId,#datasetId,'DATASET_STEWARD','DATASET_CUSTODIAN','DATASET_LEAD_REPORTER','DATASET_REPORTER_WRITE','DATASET_REPORTER_READ','DATASCHEMA_CUSTODIAN','DATASCHEMA_STEWARD','DATASCHEMA_EDITOR_WRITE','EUDATASET_CUSTODIAN','EUDATASET_STEWARD','DATACOLLECTION_CUSTODIAN','DATACOLLECTION_STEWARD','DATASET_NATIONAL_COORDINATOR','TESTDATASET_CUSTODIAN','TESTDATASET_STEWARD_SUPPORT','TESTDATASET_STEWARD','REFERENCEDATASET_CUSTODIAN','REFERENCEDATASET_LEAD_REPORTER','REFERENCEDATASET_STEWARD')")
+  @PreAuthorize("checkApiKey(#dataflowId,#providerId,#datasetId,T(org.eea.dataset.security.EndpointAuthorization)" +
+          ".getRequiredRightsForEndpoint(\"/dataschema/getSimpleSchema/dataset/{datasetId}\"))")
   @GetMapping(value = "/getSimpleSchema/dataset/{datasetId}",
           produces = MediaType.APPLICATION_JSON_VALUE)
   @ApiOperation(value = "Get dataset schema by dataset id", hidden = true)

--- a/dataset-service/src/main/java/org/eea/dataset/security/EndpointAuthorization.java
+++ b/dataset-service/src/main/java/org/eea/dataset/security/EndpointAuthorization.java
@@ -1,0 +1,41 @@
+package org.eea.dataset.security;
+
+import org.eea.security.authorization.ObjectAccessRoleEnum;
+
+import static org.eea.security.authorization.ObjectAccessRoleEnum.*;
+
+public class EndpointAuthorization {
+
+    public static ObjectAccessRoleEnum[] getRequiredRightsForEndpoint(String endpointPath) {
+        switch (endpointPath) {
+            case "/dataschema/v1/getSimpleSchema/dataset/{datasetId}":
+            case "/dataschema/getSimpleSchema/dataset/{datasetId}":
+                return new ObjectAccessRoleEnum[]{
+                    DATASET_STEWARD,
+                    DATASET_CUSTODIAN,
+                    DATASET_OBSERVER,
+                    DATASET_LEAD_REPORTER,
+                    DATASET_REPORTER_WRITE,
+                    DATASET_REPORTER_READ,
+                    DATASCHEMA_CUSTODIAN,
+                    DATASCHEMA_STEWARD,
+                    DATASCHEMA_EDITOR_WRITE,
+                    EUDATASET_CUSTODIAN,
+                    EUDATASET_STEWARD,
+                    EUDATASET_OBSERVER,
+                    DATACOLLECTION_CUSTODIAN,
+                    DATACOLLECTION_STEWARD,
+                    DATACOLLECTION_OBSERVER,
+                    DATASET_NATIONAL_COORDINATOR,
+                    TESTDATASET_CUSTODIAN,
+                    TESTDATASET_STEWARD_SUPPORT,
+                    TESTDATASET_STEWARD,
+                    TESTDATASET_OBSERVER,
+                    REFERENCEDATASET_CUSTODIAN,
+                    REFERENCEDATASET_LEAD_REPORTER,
+                    REFERENCEDATASET_STEWARD,
+                    REFERENCEDATASET_OBSERVER};
+            default: return new ObjectAccessRoleEnum[]{};
+        }
+    }
+}

--- a/dataset-service/src/test/java/org/eea/dataset/security/EndpointAuthorizationTest.java
+++ b/dataset-service/src/test/java/org/eea/dataset/security/EndpointAuthorizationTest.java
@@ -1,0 +1,77 @@
+package org.eea.dataset.security;
+
+import org.eea.security.authorization.ObjectAccessRoleEnum;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.*;
+
+@RunWith(Parameterized.class)
+public class EndpointAuthorizationTest {
+
+    private final String endpointPath;
+    private final ObjectAccessRoleEnum[] expectedRoles;
+
+    public EndpointAuthorizationTest(String endpointPath, ObjectAccessRoleEnum[] expectedRoles) {
+        this.endpointPath = endpointPath;
+        this.expectedRoles = expectedRoles;
+    }
+
+    @Parameters(name = "{index}: endpoint={0} → expected roles count={1}")
+    public static Collection<Object[]> data() {
+        ObjectAccessRoleEnum[] fullRoles = {
+                ObjectAccessRoleEnum.DATASET_STEWARD,
+                ObjectAccessRoleEnum.DATASET_CUSTODIAN,
+                ObjectAccessRoleEnum.DATASET_OBSERVER,
+                ObjectAccessRoleEnum.DATASET_LEAD_REPORTER,
+                ObjectAccessRoleEnum.DATASET_REPORTER_WRITE,
+                ObjectAccessRoleEnum.DATASET_REPORTER_READ,
+                ObjectAccessRoleEnum.DATASCHEMA_CUSTODIAN,
+                ObjectAccessRoleEnum.DATASCHEMA_STEWARD,
+                ObjectAccessRoleEnum.DATASCHEMA_EDITOR_WRITE,
+                ObjectAccessRoleEnum.EUDATASET_CUSTODIAN,
+                ObjectAccessRoleEnum.EUDATASET_STEWARD,
+                ObjectAccessRoleEnum.EUDATASET_OBSERVER,
+                ObjectAccessRoleEnum.DATACOLLECTION_CUSTODIAN,
+                ObjectAccessRoleEnum.DATACOLLECTION_STEWARD,
+                ObjectAccessRoleEnum.DATACOLLECTION_OBSERVER,
+                ObjectAccessRoleEnum.DATASET_NATIONAL_COORDINATOR,
+                ObjectAccessRoleEnum.TESTDATASET_CUSTODIAN,
+                ObjectAccessRoleEnum.TESTDATASET_STEWARD_SUPPORT,
+                ObjectAccessRoleEnum.TESTDATASET_STEWARD,
+                ObjectAccessRoleEnum.TESTDATASET_OBSERVER,
+                ObjectAccessRoleEnum.REFERENCEDATASET_CUSTODIAN,
+                ObjectAccessRoleEnum.REFERENCEDATASET_LEAD_REPORTER,
+                ObjectAccessRoleEnum.REFERENCEDATASET_STEWARD,
+                ObjectAccessRoleEnum.REFERENCEDATASET_OBSERVER
+        };
+
+        return Arrays.asList(new Object[][]{
+                // Matching endpoints - should return roles list.
+                {"/dataschema/v1/getSimpleSchema/dataset/{datasetId}", fullRoles},
+                {"/dataschema/getSimpleSchema/dataset/{datasetId}",      fullRoles},
+
+                // Non-matching endpoints - should return empty array
+                {"/dataschema/v1/getSimpleSchema/dataset/123", new ObjectAccessRoleEnum[]{}},
+                {"/dataschema/getSimpleSchema/dataset/abc",    new ObjectAccessRoleEnum[]{}},
+                {"/other/endpoint",                            new ObjectAccessRoleEnum[]{}},
+                {"",                                           new ObjectAccessRoleEnum[]{}}
+        });
+    }
+
+    @Test
+    public void testGetRequiredRightsForEndpoint() {
+        ObjectAccessRoleEnum[] actual = EndpointAuthorization.getRequiredRightsForEndpoint(endpointPath);
+
+        if (expectedRoles.length == 0) {
+            assertEquals(0, actual.length);
+        } else {
+            assertArrayEquals(expectedRoles, actual);
+        }
+    }
+}


### PR DESCRIPTION
- Extracted hardcoded pre-authorization roles into an external location.
- Add OBSERVER roles for  /dataschema/getSimpleSchema/dataset/{datasetId} endpoint