### PR TITLE
295404 flag QC rules as invalid if they have trailing comments

### DIFF
--- a/validation-service/src/main/java/org/eea/validation/controller/RulesControllerImpl.java
+++ b/validation-service/src/main/java/org/eea/validation/controller/RulesControllerImpl.java
@@ -39,6 +39,7 @@ import org.eea.interfaces.vo.recordstore.ProcessVO;
 import org.eea.interfaces.vo.recordstore.enums.ProcessStatusEnum;
 import org.eea.thread.ThreadPropertiesManager;
 import org.eea.validation.exception.EEAForbiddenSQLCommandException;
+import org.eea.validation.exception.EEAInvalidSQLCommentsException;
 import org.eea.validation.exception.EEAInvalidSQLException;
 import org.eea.validation.mapper.RuleMapper;
 import org.eea.validation.service.RulesService;
@@ -1109,6 +1110,11 @@ public class RulesControllerImpl implements RulesController {
       obtainedTableValues =
               sqlRulesService.runSqlRule(datasetId, sqlRule.getSqlRule(), showInternalFields);
       LOG.info("Successfully ran sql rule {} for datasetId {}", sqlRule.getSqlRule(), datasetId);
+    } catch (EEAInvalidSQLCommentsException e){
+      LOG.error(
+              "There was an error trying to execute the SQL Rule: {} for datasetId {}. Check your SQL comments.",
+              sqlRule.getSqlRule(), datasetId, e);
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "SQL validation failed, sql ends with a comment.");
     } catch (EEAInvalidSQLException e) {
       LOG.error(
               "There was an error trying to execute the SQL Rule: {} for datasetId {}. Check your SQL Syntax.",

--- a/validation-service/src/main/java/org/eea/validation/exception/EEAInvalidSQLCommentsException.java
+++ b/validation-service/src/main/java/org/eea/validation/exception/EEAInvalidSQLCommentsException.java
@@ -1,0 +1,48 @@
+package org.eea.validation.exception;
+
+import org.eea.exception.EEAException;
+
+/**
+ * The Class EEAInvalidSQLCommentsException.
+ */
+public class EEAInvalidSQLCommentsException extends EEAException {
+
+  /** The Constant serialVersionUID. */
+  private static final long serialVersionUID = 139711384193913014L;
+
+  /**
+   * Instantiates a new invalid SQL exception.
+   *
+   * @param message the message
+   * @param cause the cause
+   */
+  public EEAInvalidSQLCommentsException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  /**
+   * Instantiates a new invalid SQL exception.
+   *
+   * @param message the message
+   */
+  public EEAInvalidSQLCommentsException(String message) {
+    super(message);
+  }
+
+  /**
+   * Instantiates a new invalid SQL exception.
+   */
+  public EEAInvalidSQLCommentsException() {
+    super();
+  }
+
+  /**
+   * Instantiates a new invalid file exception.
+   *
+   * @param cause the cause
+   */
+  public EEAInvalidSQLCommentsException(Throwable cause) {
+    super(cause);
+  }
+
+}

--- a/validation-service/src/main/java/org/eea/validation/service/impl/SqlRulesServiceImpl.java
+++ b/validation-service/src/main/java/org/eea/validation/service/impl/SqlRulesServiceImpl.java
@@ -44,6 +44,7 @@ import org.eea.kafka.domain.EventType;
 import org.eea.kafka.domain.NotificationVO;
 import org.eea.kafka.utils.KafkaSenderUtils;
 import org.eea.validation.exception.EEAForbiddenSQLCommandException;
+import org.eea.validation.exception.EEAInvalidSQLCommentsException;
 import org.eea.validation.exception.EEAInvalidSQLException;
 import org.eea.validation.mapper.RuleMapper;
 import org.eea.validation.persistence.data.domain.FieldValidation;
@@ -444,6 +445,7 @@ public class SqlRulesServiceImpl implements SqlRulesService {
     try {
 
       if (checkQuerySyntax(sqlRule)) {
+        validateNoTrailingComments(datasetId, sqlRule);
         ids = getListOfDatasetsOnQuery(sqlRule);
         datasetIds = new ArrayList<>(ids);
         checkDatasetFromSameDataflow(dataSetMetabaseVO, ids);
@@ -496,6 +498,8 @@ public class SqlRulesServiceImpl implements SqlRulesService {
       }
     } catch (StringIndexOutOfBoundsException e) {
       throw new StringIndexOutOfBoundsException("SQL sentence has wrong format, please check.");
+    } catch (EEAInvalidSQLCommentsException e){
+      throw new EEAInvalidSQLCommentsException(e.getMessage());
     } catch (EEAForbiddenSQLCommandException e) {
       throw new EEAForbiddenSQLCommandException("SQL Command not allowed in SQL Rule.", e);
     } catch (EEAInvalidSQLException e) {
@@ -528,6 +532,7 @@ public class SqlRulesServiceImpl implements SqlRulesService {
 
     try {
       if (checkQuerySyntax(sqlRule)) {
+        validateNoTrailingComments(datasetId, sqlRule);
         ids = getListOfDatasetsOnQuery(sqlRule);
         checkDatasetFromSameDataflow(dataSetMetabaseVO, ids);
         if (!ids.isEmpty()) {
@@ -555,6 +560,8 @@ public class SqlRulesServiceImpl implements SqlRulesService {
       }
     } catch (StringIndexOutOfBoundsException e) {
       throw new StringIndexOutOfBoundsException("SQL sentence has wrong format, please check it");
+    } catch (EEAInvalidSQLCommentsException e) {
+      throw new EEAInvalidSQLCommentsException(e.getMessage(), e);
     } catch (EEAForbiddenSQLCommandException e) {
       throw new EEAForbiddenSQLCommandException("SQL Command not allowed in SQL Rule.", e);
     } catch (EEAInvalidSQLException e) {
@@ -601,6 +608,12 @@ public class SqlRulesServiceImpl implements SqlRulesService {
       query = sqlCountryCompanyOrganizationCodeUtils.replaceCodesIfNeeded(dataSetMetabaseVO.getId(), query);
 
       if (checkQuerySyntax(query)) {
+        try {
+          validateNoTrailingComments(dataSetMetabaseVO.getId(), query);
+        } catch (EEAInvalidSQLCommentsException e){
+          isSQLCorrect = "SQL validation failed, sql ends with a comment.";
+          LOG.error(e.getMessage());
+        }
         List<String> ids = getListOfDatasetsOnQuery(query);
         checkDatasetFromSameDataflow(dataSetMetabaseVO, ids);
         if (!ids.isEmpty()) {
@@ -641,6 +654,119 @@ public class SqlRulesServiceImpl implements SqlRulesService {
       LOG.info("Rule validation passed: {}", rule);
     }
     return isSQLCorrect;
+  }
+
+  /**
+   * Validates that a SQL query does not end with a comment.
+   * This method checks for trailing line comments like `-- abc` or block comments `/* abc *​/`
+   * It ignores whitespace and semicolons at the end.
+   * It also ignores comments inside strings.
+   * </p>
+   *
+   * @param sql the SQL query string to validate
+   * @throws EEAInvalidSQLCommentsException if the SQL ends with a comment
+   */
+  private void validateNoTrailingComments(Long datasetId, String sql) throws EEAInvalidSQLCommentsException {
+    if (sql == null || sql.isBlank()) return;
+
+    final char NEWLINE = '\n';
+    final char CARRIAGE_RETURN = '\r';
+    final char SINGLE_QUOTE = '\'';
+    final char DOUBLE_QUOTE = '"';
+    final char ASTERISK = '*';
+    final char SLASH = '/';
+    final char DASH = '-';
+    final char SEMICOLON = ';';
+    final char NULL_CHAR = '\0';
+
+    final String LINE_COMMENT_START = "--";
+    final String BLOCK_COMMENT_START = "/*";
+    final String BLOCK_COMMENT_END = "*/";
+
+    // tracking some cases
+    boolean insideSingleQuotedString = false;
+    boolean insideDoubleQuotedString = false;
+    boolean insideLineComment = false;
+    boolean insideBlockComment = false;
+
+    int lastMeaningfulSqlCharacterIndex = -1;
+    int lastCommentStartIndex = -1;
+
+    // iterate through given SQL string character by character
+    for (int index = 0; index < sql.length(); index++) {
+
+      char character = sql.charAt(index);
+      char nextCharacter = (index + 1 < sql.length()) ? sql.charAt(index + 1) : NULL_CHAR;
+
+      // handle exiting line comments
+      if (insideLineComment) {
+        if (character == NEWLINE || character == CARRIAGE_RETURN) {
+          insideLineComment = false;
+        }
+        continue;
+      }
+
+      // handle exiting block comments
+      if (insideBlockComment) {
+        if (character == ASTERISK && nextCharacter == SLASH) {
+          insideBlockComment = false;
+          index++; // skip '/'
+        }
+        continue;
+      }
+
+      // handle the string literals
+      if (insideSingleQuotedString) {
+        if (character == SINGLE_QUOTE && nextCharacter != SINGLE_QUOTE) {
+          insideSingleQuotedString = false;
+        }
+        continue;
+      }
+
+      if (insideDoubleQuotedString) {
+        if (character == DOUBLE_QUOTE) {
+          insideDoubleQuotedString = false;
+        }
+        continue;
+      }
+
+      // detect entering string literals
+      if (character == SINGLE_QUOTE) {
+        insideSingleQuotedString = true;
+        lastMeaningfulSqlCharacterIndex = index;
+        continue;
+      }
+
+      if (character == DOUBLE_QUOTE) {
+        insideDoubleQuotedString = true;
+        lastMeaningfulSqlCharacterIndex = index;
+        continue;
+      }
+
+      // detect the entering comments
+      if (character == DASH && nextCharacter == DASH) {
+        insideLineComment = true;
+        lastCommentStartIndex = index;
+        index++; // skip second '-'
+        continue;
+      }
+
+      if (character == SLASH && nextCharacter == ASTERISK) {
+        insideBlockComment = true;
+        lastCommentStartIndex = index;
+        index++; // skip '*'
+        continue;
+      }
+
+      // track meaningful SQL characters
+      if (!Character.isWhitespace(character) && character != SEMICOLON) {
+        lastMeaningfulSqlCharacterIndex = index;
+      }
+    }
+
+    if (lastCommentStartIndex > lastMeaningfulSqlCharacterIndex) {
+      throw new EEAInvalidSQLCommentsException("SQL validation failed: SQL ends with a trailing comment. datasetId: " + datasetId + " given SQL: " + sql);
+    }
   }
 
   /**


### PR DESCRIPTION
This was a tricky implementation, I have tested what the ticket implies in 5 distinct cases about last SQL token being comment:
* no comment (ensure everything still working good)
* trailing inline comment
* trailing block comment
* after new line inline comment
* after new line block comment

The postman collection file that I tested on a citus and a big data dataflow:
[295404 Flag QC rules as invalid if the have comments.postman_collection.json](https://github.com/user-attachments/files/24409479/295404.Flag.QC.rules.as.invalid.if.the.have.comments.postman_collection.json)
