### PR TITLE
Remove race condition in ValidationHelper.finishProcessInMap() that c…

### DIFF
--- a/recordstore-service/src/main/java/org/eea/recordstore/service/impl/ProcessServiceImpl.java
+++ b/recordstore-service/src/main/java/org/eea/recordstore/service/impl/ProcessServiceImpl.java
@@ -149,11 +149,11 @@ public class ProcessServiceImpl implements ProcessService {
         processToUpdate.setPriority(priority);
       }
       try {
-
         processRepository.save(processToUpdate);
         processRepository.flush();
-      } catch (ObjectOptimisticLockingFailureException e) {
-        updated = false;
+      } catch (Exception e) {
+          LOG.error("Error updating process {} ", processId, e);
+          updated = false;
       }
     }
     return updated;

--- a/validation-service/src/main/java/org/eea/validation/util/ValidationHelper.java
+++ b/validation-service/src/main/java/org/eea/validation/util/ValidationHelper.java
@@ -112,7 +112,7 @@ public class ValidationHelper implements DisposableBean {
   private static final Logger LOG = LoggerFactory.getLogger(ValidationHelper.class);
 
   /** The processes map. */
-  private Map<String, ValidationProcessVO> processesMap;
+  private final Map<String, ValidationProcessVO> processesMap;
 
   /** The validation executor service. */
   private ExecutorService validationExecutorService;
@@ -278,12 +278,13 @@ public class ValidationHelper implements DisposableBean {
         if (removed != null) {
           LOG.info("Removing process {} from processesMap ", processId);
           result = true;
-        } else {
+        }
+        else {
           LOG.info("Process {} not removed from processesMap", processId);
         }
-      } else {
-        LOG.info("Process {} not found in processesMap" + processId);
-        result = true;
+      }
+      else {
+        LOG.info("Process {} not found in processesMap" , processId);
       }
     }
     return result;
@@ -1566,7 +1567,8 @@ public class ValidationHelper implements DisposableBean {
           }
           isFinished = true;
         }
-      } else {
+      }
+      else {
         if (taskRepository.isProcessEnding(processId)) {
           try {
             LOG.info("Process {} for dataset {} ending", processId, datasetId);


### PR DESCRIPTION
When a validation task finishes execution it's thread calls ValidationHelper.finishProcessInMap() which checks if the entire process is finished (no more validation tasks) and if so, it removes the process from the process HashMap and proceeds to update it's status to FINISHED. When two or more validation threads finish at the same time, due to a faulty implementation of finishProcessInMap() method, they both attempt to update the same process and this produces a hibernate transaction exception. This will fix the race condition and remove pollution from logs.