### PR TITLE
Handle any NPEs and Blank geometries to prevent tasks from being canceled

### DIFF
--- a/validation-service/src/main/java/org/eea/validation/service/impl/DremioNonSqlRulesExecuteServiceImpl.java
+++ b/validation-service/src/main/java/org/eea/validation/service/impl/DremioNonSqlRulesExecuteServiceImpl.java
@@ -430,7 +430,13 @@ public class DremioNonSqlRulesExecuteServiceImpl implements DremioRulesExecuteSe
             int parameterLength = method.getParameters().length;
             switch (parameterLength) {
                 case 1:
-                    isValid = (boolean) method.invoke(object, getConvertedString(rs, fieldName));  //DremioNonSQLValidationUtils methods
+                    Class<?> parameterType = method.getParameters()[0].getType();
+                    // In case of isBlankPoint where the method accepts a byte[], we cast the raw bytes from the row to byte[].
+                    if (parameterType.equals(byte[].class)) {
+                        isValid = (boolean) method.invoke(object, (byte[]) rs.getObject(fieldName));
+                    } else {
+                        isValid = (boolean) method.invoke(object, getConvertedString(rs, fieldName));
+                    }
                     break;
                 case 2:
                     isValid = (boolean) method.invoke(object, getConvertedString(rs, fieldName), parameters.get(1));  //ValidationDroolsUtils methods

--- a/validation-service/src/main/java/org/eea/validation/service/impl/DremioNonSqlRulesExecuteServiceImpl.java
+++ b/validation-service/src/main/java/org/eea/validation/service/impl/DremioNonSqlRulesExecuteServiceImpl.java
@@ -15,6 +15,7 @@ import org.eea.datalake.service.SpatialDataHandling;
 import org.eea.datalake.service.annotation.ImportDataLakeCommons;
 import org.eea.datalake.service.model.S3PathResolver;
 import org.eea.exception.DremioValidationException;
+import org.eea.exception.EEAException;
 import org.eea.interfaces.controller.dataset.DatasetMetabaseController;
 import org.eea.interfaces.controller.dataset.DatasetSchemaController.DatasetSchemaControllerZuul;
 import org.eea.interfaces.vo.dataset.DataSetMetabaseVO;
@@ -153,16 +154,26 @@ public class DremioNonSqlRulesExecuteServiceImpl implements DremioRulesExecuteSe
             query.append("select record_id,").append(fieldName != null ? UtilityClass.addQuotesToFieldNames(fieldName) : "").append(" from ").append(s3Service.getTableAsFolderQueryPath(dataTableResolver, path));
             SqlRowSet rs = dremioJdbcTemplate.queryForRowSet(query.toString());
 
-            Method method = null;
             List<String> classes = new ArrayList<>(Arrays.asList(DREMIO_NON_SQL_VALIDATION_UTILS, VALIDATION_DROOLS_UTILS, GEOMETRY_VALIDATION_UTILS, GEO_JSON_VALIDATION_UTILS));
             Class<?> cls = null;
+            Method method = null;
             for (String className : classes) {
                 cls = Class.forName(className);
-                method = dremioRulesService.getRuleMethodFromClass(ruleMethodName, cls);
-                if (method != null) {
+                Method foundMethod = dremioRulesService.getRuleMethodFromClass(ruleMethodName, cls);
+                if (foundMethod != null) {
+                    method = foundMethod;
                     break;
                 }
             }
+
+            // In case of an unhandled ruleMethodName or actual null value. Exception passed in
+            // ValidationTasksExecutorThread.run() to avoid npe.
+            if (method == null) {
+                LOG.error("Rule method not found. ruleId={}, shortCode={}, datasetId={}, taskId={}, whenConditionMethod={}, ruleMethodName={}, classes={}",
+                    ruleId, ruleVO.getShortCode(), datasetId, taskId, ruleVO.getWhenConditionMethod(), ruleMethodName, classes);
+                throw new DremioValidationException("Rule method not found: ruleMethodName: " + ruleMethodName);
+            }
+
             Method factoryMethod = cls.getDeclaredMethod(GET_INSTANCE);
             Object object = factoryMethod.invoke(null, null);
 

--- a/validation-service/src/main/java/org/eea/validation/util/datalake/DremioNonSQLValidationUtils.java
+++ b/validation-service/src/main/java/org/eea/validation/util/datalake/DremioNonSQLValidationUtils.java
@@ -2,6 +2,10 @@ package org.eea.validation.util.datalake;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eea.validation.util.ValidationDroolsUtils;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKBReader;
 
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
@@ -117,8 +121,37 @@ public class DremioNonSQLValidationUtils {
         return ValidationDroolsUtils.validateRegExpression(value,"REG_EXP_PHONE");
     }
 
-    public boolean isBlankPoint(String value) {
-      return value != null && !value.isEmpty();
+    public boolean isBlankPoint(byte[] byteArray) {
+      if (byteArray == null || byteArray.length == 0) {
+        return false;
+      }
+      try {
+        Geometry geometry = new WKBReader().read(byteArray);
+        if (geometry == null) {
+          return false;
+        }
+
+        if (!"Point".equalsIgnoreCase(geometry.getGeometryType())) {
+          return true;
+        }
+
+        Coordinate coordinates = geometry.getCoordinate();
+        if (coordinates == null) {
+          return false;
+        }
+
+        double x = coordinates.getX();
+        double y = coordinates.getY();
+
+        // Blank point [0,0] coordinates.
+        if (x == 0d && y == 0d) {
+          return false;
+        }
+
+        return true;
+      } catch (Exception e) {
+        return false;
+      }
     }
 }
 

--- a/validation-service/src/main/java/org/eea/validation/util/datalake/DremioNonSQLValidationUtils.java
+++ b/validation-service/src/main/java/org/eea/validation/util/datalake/DremioNonSQLValidationUtils.java
@@ -116,6 +116,10 @@ public class DremioNonSQLValidationUtils {
         }
         return ValidationDroolsUtils.validateRegExpression(value,"REG_EXP_PHONE");
     }
+
+    public boolean isBlankPoint(String value) {
+      return value != null && !value.isEmpty();
+    }
 }
 
 


### PR DESCRIPTION
https://taskman.eionet.europa.eu/issues/295784
In DremioNonSqlValidationUtil was added the isBlankPoint() method which checks for empty, null or coordinated [0,0] as invalid.
In DremioNonSqlRulesExecuteService a ckeck was added that immediately throughs a DremioValidationException along with a LOG with all the needed data in case of method == null. The method will also stay null if ruleMethodName has an unhandled method.