### PR TITLE
feat: add table lock functionality to prevent schema changes if table has data

### DIFF
--- a/frontend-service/src/conf/messages.en.json
+++ b/frontend-service/src/conf/messages.en.json
@@ -1595,6 +1595,8 @@
     "tableDataByIdError": "The data of the table could not be loaded. Please try again or contact the Service Desk if the issue persists.",
     "tableInfo": "Table info",
     "tableIsNotCreated": "The table {:tableName} is not created in the design, please check it.<br>",
+    "tableLockedDueToData": "The table is locked because it has data. Delete the data first if you want to modify the schema.",
+    "tableLockedDueToDataAction": "This action is locked because the table has data. Delete the data first if you want to modify the schema.",
     "tableRelationsTitle": "Note: By default, all reference field values must be found in the target field values",
     "tables": "Tables",
     "tablesAndFields": "Tables & Fields",

--- a/frontend-service/src/views/DatasetDesigner/_components/TabsDesigner/TabsDesigner.jsx
+++ b/frontend-service/src/views/DatasetDesigner/_components/TabsDesigner/TabsDesigner.jsx
@@ -84,6 +84,7 @@ export const TabsDesigner = ({
   const [tabHasErrors, setTabHasErrors] = useState(false);
   const [warningMessage, setWarningMessage] = useState();
   const [warningMessageTitle, setWarningMessageTitle] = useState();
+  const [tableHasData, setTableHasData] = useState({});
 
   useEffect(() => {
     if (!isNil(datasetSchema) && !isEmpty(datasetSchema)) {
@@ -116,6 +117,16 @@ export const TabsDesigner = ({
       renderErrors(warningMessageTitle, warningMessage);
     }
   }, [isWarningDialogVisible]);
+
+  useEffect(() => {
+    if (!isEmpty(tabs) && bigData) {
+      tabs.forEach(tab => {
+        if (!tab.addTab) {
+          checkTableHasData(tab.tableSchemaId);
+        }
+      });
+    }
+  }, [tabs]);
 
   const onChangeFields = (fields, isLinkChange, tabSchemaId) => {
     const inmTabs = [...tabs];
@@ -189,7 +200,11 @@ export const TabsDesigner = ({
 
       if (bigData) {
         checkTabs?.forEach(item => {
-          if (!item?.dataAreManuallyEditable) length -= 1;
+          const isTableLocked = tableHasData[item.tableSchemaId] === true;
+
+          if (!item?.dataAreManuallyEditable || isTableLocked) {
+            length -= 1;
+          }
         });
       }
 
@@ -386,6 +401,26 @@ export const TabsDesigner = ({
     }
   };
 
+  const checkTableHasData = async tableSchemaId => {
+    try {
+      const response = await DatasetService.getTableDataDL({
+        datasetId: datasetId,
+        tableSchemaId: tableSchemaId,
+        pageNum: 0,
+        pageSize: 1,
+        levelError: ['CORRECT', 'INFO', 'WARNING', 'ERROR', 'BLOCKER']
+      });
+
+      const hasData = response?.records?.length > 0;
+      setTableHasData(prev => ({ ...prev, [tableSchemaId]: hasData }));
+
+      return hasData;
+    } catch (error) {
+      console.error('TabsDesigner - checkTableHasData.', error);
+      return false;
+    }
+  };
+
   const errorDialogFooter = (
     <div className="ui-dialog-buttonpane p-clearfix">
       <Button
@@ -477,6 +512,7 @@ export const TabsDesigner = ({
         isEditingEnabled={isEditingEnabled}
         isErrorDialogVisible={isErrorDialogVisible}
         isIcebergCreated={isIcebergCreated}
+        isTableLockedDueToData={tableHasData[idx.tableSchemaId]}
         isWarningDialogVisible={isWarningDialogVisible}
         maxLength={maxLength}
         name="TabsDesigner"
@@ -510,6 +546,7 @@ export const TabsDesigner = ({
                   hasPKReferenced={tab.hasPKReferenced}
                   header={tab.header}
                   index={tab.index}
+                  isTableLockedDueToData={tableHasData[tab.tableSchemaId]}
                   key={tab.index}
                   manualEdit={tab.dataAreManuallyEditable}
                   newTab={tab.newTab}
@@ -520,7 +557,11 @@ export const TabsDesigner = ({
                   rightIconTooltip={getRightIconTooltip(tab)}
                   tableSchemaId={tab.tableSchemaId}
                   toPrefill={tab.toPrefill}>
-                  {(tabs.length > 0 && (isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled)) ||
+                  {(tabs.length > 0 &&
+                    (isDataflowOpen ||
+                      isDesignDatasetEditorRead ||
+                      isEditingEnabled ||
+                      tableHasData[tab.tableSchemaId])) ||
                   tabs.length > 1 ? (
                     <FieldsDesigner
                       autoFocus={false}
@@ -542,6 +583,7 @@ export const TabsDesigner = ({
                       isGroupedValidationSelected={isGroupedValidationSelected}
                       isIcebergCreated={isIcebergCreated}
                       isReferenceDataset={isReferenceDataset}
+                      isTableLockedDueToData={tableHasData[tab.tableSchemaId]}
                       key={tab.index}
                       manageDialogs={manageDialogs}
                       manageUniqueConstraint={manageUniqueConstraint}

--- a/frontend-service/src/views/DatasetDesigner/_components/TabsDesigner/_components/FieldsDesigner/FieldsDesigner.jsx
+++ b/frontend-service/src/views/DatasetDesigner/_components/TabsDesigner/_components/FieldsDesigner/FieldsDesigner.jsx
@@ -58,6 +58,7 @@ export const FieldsDesigner = ({
   isGroupedValidationSelected,
   isIcebergCreated,
   isReferenceDataset,
+  isTableLockedDueToData = false,
   manageDialogs,
   manageUniqueConstraint,
   onChangeFields,
@@ -689,6 +690,7 @@ export const FieldsDesigner = ({
           isIcebergCreated={isIcebergCreated}
           isLoading={isLoading}
           isReferenceDataset={isReferenceDataset}
+          isTableLockedDueToData={isTableLockedDueToData}
           onCheckPkCheckbox={onCheckPk}
           onCodelistAndLinkShow={onCodelistAndLinkShow}
           onFieldDragAndDrop={onFieldDragAndDrop}
@@ -756,6 +758,7 @@ export const FieldsDesigner = ({
               isIcebergCreated={isIcebergCreated}
               isLoading={isLoading}
               isReferenceDataset={isReferenceDataset}
+              isTableLockedDueToData={isTableLockedDueToData}
               key={field.fieldId}
               markedForDeletion={markedForDeletion}
               onBulkCheck={onBulkCheck}
@@ -900,34 +903,53 @@ export const FieldsDesigner = ({
       return styles.activeDragAndDropItems;
     }
   };
-
   return (
     <Fragment>
       {isEditingEnabled && !viewType['tabularData'] && (
-        <div className={styles.icebergWarning} role="alert">
-          <strong>{resourcesContext.messages['info']}: </strong>
+        <div className={styles.disabledFieldsWarning} role="alert">
+          <Button
+            className={`${styles.disabledFieldsInfoBtn} p-button-rounded p-button-secondary-transparent`}
+            icon="infoCircle"
+          />
           {resourcesContext.messages['disableEditingBeforeSchemaChange']}
         </div>
       )}
+
+      {bigData && isTableLockedDueToData && !isEditingEnabled && !viewType['tabularData'] && (
+        <div className={styles.disabledFieldsWarning} role="alert">
+          <Button
+            className={`${styles.disabledFieldsInfoBtn} p-button-rounded p-button-secondary-transparent`}
+            icon="infoCircle"
+          />
+          {resourcesContext.messages['tableLockedDueToData']}
+        </div>
+      )}
+
       <Toolbar>
         <div className="p-toolbar-group-left">
           <Button
             className={`p-button-rounded p-button-secondary-transparent ${
-              (!isDataflowOpen && !isDesignDatasetEditorRead) || !isEditingEnabled ? 'p-button-animated-blink' : null
+              (!isDataflowOpen && !isDesignDatasetEditorRead) || !isEditingEnabled || !isTableLockedDueToData
+                ? 'p-button-animated-blink'
+                : null
             }`}
             disabled={
               (isAdmin && (!isCustodian || !isDataflowCustodian)) ||
               isDataflowOpen ||
               isDesignDatasetEditorRead ||
-              isEditingEnabled
+              isEditingEnabled ||
+              isTableLockedDueToData
             }
             icon="import"
             label={resourcesContext.messages['importTableSchema']}
             onClick={() => manageDialogs('isImportTableSchemaDialogVisible', true)}
+            tooltip={isTableLockedDueToData ? resourcesContext.messages['tableLockedDueToDataAction'] : null}
           />
           <Button
             className={`p-button-rounded p-button-secondary-transparent ${
-              (!isDataflowOpen && !isDesignDatasetEditorRead) || !isEditingEnabled ? 'p-button-animated-blink' : null
+              (!isDataflowOpen && !isDesignDatasetEditorRead) || !isEditingEnabled || !isTableLockedDueToData
+                ? 'p-button-animated-blink'
+                : null
             }`}
             disabled={isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled}
             icon="export"
@@ -936,7 +958,9 @@ export const FieldsDesigner = ({
           />
           <Button
             className={`p-button-secondary-transparent ${
-              (!isDesignDatasetEditorRead && (!isDataflowOpen || !isReferenceDataset)) || !isEditingEnabled
+              (!isDesignDatasetEditorRead && (!isDataflowOpen || !isReferenceDataset)) ||
+              !isEditingEnabled ||
+              !isTableLockedDueToData
                 ? 'p-button-animated-blink'
                 : null
             } datasetSchema-uniques-help-step`}
@@ -954,7 +978,9 @@ export const FieldsDesigner = ({
           />
           <Button
             className={`p-button-secondary-transparent ${
-              (!isDesignDatasetEditorRead && (!isDataflowOpen || !isReferenceDataset)) || !isEditingEnabled
+              (!isDesignDatasetEditorRead && (!isDataflowOpen || !isReferenceDataset)) ||
+              !isEditingEnabled ||
+              !isTableLockedDueToData
                 ? 'p-button-animated-blink'
                 : null
             } datasetSchema-rowConstraint-help-step`}
@@ -1002,7 +1028,9 @@ export const FieldsDesigner = ({
             <span
               className={styles.switchTextInput}
               id={`${table.tableSchemaId}_check_readOnly_label`}
-              style={{ opacity: isDesignDatasetEditorRead || isDataflowOpen || isEditingEnabled ? 0.5 : 1 }}>
+              style={{
+                opacity: isDesignDatasetEditorRead || isDataflowOpen || isEditingEnabled ? 0.5 : 1
+              }}>
               {resourcesContext.messages['readOnlyTable']}
             </span>
             <Checkbox
@@ -1020,7 +1048,9 @@ export const FieldsDesigner = ({
             <span
               className={styles.switchTextInput}
               id={`${table.tableSchemaId}_check_to_prefill_label`}
-              style={{ opacity: isDesignDatasetEditorRead || isDataflowOpen || isEditingEnabled ? 0.5 : 1 }}>
+              style={{
+                opacity: isDesignDatasetEditorRead || isDataflowOpen || isEditingEnabled ? 0.5 : 1
+              }}>
               {resourcesContext.messages['prefilled']}
             </span>
             <Checkbox
@@ -1045,7 +1075,9 @@ export const FieldsDesigner = ({
             <span
               className={styles.switchTextInput}
               id={`${table.tableSchemaId}_check_fixed_number_label`}
-              style={{ opacity: isDesignDatasetEditorRead || isDataflowOpen || isEditingEnabled ? 0.5 : 1 }}>
+              style={{
+                opacity: isDesignDatasetEditorRead || isDataflowOpen || isEditingEnabled ? 0.5 : 1
+              }}>
               {resourcesContext.messages['fixedNumber']}
             </span>
             <Checkbox
@@ -1066,7 +1098,9 @@ export const FieldsDesigner = ({
             <span
               className={styles.switchTextInput}
               id={`${table.tableSchemaId}_check_not_empty_label`}
-              style={{ opacity: isDesignDatasetEditorRead || isDataflowOpen || isEditingEnabled ? 0.5 : 1 }}>
+              style={{
+                opacity: isDesignDatasetEditorRead || isDataflowOpen || isEditingEnabled ? 0.5 : 1
+              }}>
               {resourcesContext.messages['notEmpty']}
             </span>
             <Checkbox
@@ -1088,7 +1122,9 @@ export const FieldsDesigner = ({
               <span
                 className={styles.switchTextInput}
                 id={`${table.tableSchemaId}_check_manual_edit_label`}
-                style={{ opacity: isDesignDatasetEditorRead || isDataflowOpen || isEditingEnabled ? 0.5 : 1 }}>
+                style={{
+                  opacity: isDesignDatasetEditorRead || isDataflowOpen || isEditingEnabled ? 0.5 : 1
+                }}>
                 {resourcesContext.messages['manualEdit']}
               </span>
               <Checkbox

--- a/frontend-service/src/views/DatasetDesigner/_components/TabsDesigner/_components/FieldsDesigner/FieldsDesigner.module.scss
+++ b/frontend-service/src/views/DatasetDesigner/_components/TabsDesigner/_components/FieldsDesigner/FieldsDesigner.module.scss
@@ -185,7 +185,7 @@
   transition: 0.5s !important;
 }
 
-.icebergWarning {
+.disabledFieldsWarning {
   background: #e6f4fa;
   color: #31708f;
   border: 1px solid #bce8f1;
@@ -227,6 +227,14 @@
 .inactiveDragAndDropItems ~ div > div:first-child {
   svg {
     opacity: 0.5 !important;
+  }
+}
+
+.disabledFieldsInfoBtn {
+  color: var(--datatable-header-info-button-color) !important;
+  font-size: 12pt !important;
+  &:focus {
+    box-shadow: none !important;
   }
 }
 

--- a/frontend-service/src/views/DatasetDesigner/_components/TabsDesigner/_components/FieldsDesigner/_components/FieldDesigner/FieldDesigner.jsx
+++ b/frontend-service/src/views/DatasetDesigner/_components/TabsDesigner/_components/FieldsDesigner/_components/FieldDesigner/FieldDesigner.jsx
@@ -70,6 +70,7 @@ export const FieldDesigner = ({
   isLoading = false,
   isIcebergCreated,
   isReferenceDataset,
+  isTableLockedDueToData = false,
   markedForDeletion,
   onBulkCheck,
   onCheckPkCheckbox,
@@ -917,7 +918,6 @@ export const FieldDesigner = ({
       );
     }
   };
-
   const renderCheckboxes = () => (
     <Fragment>
       <div className={`${styles.draggableFieldContentCell} ${styles.smallItems}`}>
@@ -949,7 +949,8 @@ export const FieldDesigner = ({
               isDataflowOpen ||
               isDesignDatasetEditorRead ||
               isEditingEnabled ||
-              isLoading
+              isLoading ||
+              (addField && isTableLockedDueToData)
             }
             id={`${fieldId}_check_pk`}
             inputId={`${fieldId}_check_pk`}
@@ -981,7 +982,8 @@ export const FieldDesigner = ({
               isDataflowOpen ||
               isDesignDatasetEditorRead ||
               isEditingEnabled ||
-              isLoading
+              isLoading ||
+              (addField && isTableLockedDueToData)
             }
             id={`${fieldId}_check_required`}
             inputId={`${fieldId}_check_required`}
@@ -1005,7 +1007,7 @@ export const FieldDesigner = ({
             className={`datasetSchema-readOnly-help-step ${
               isDragging ? styles.dragAndDropActive : styles.dragAndDropInactive
             } ${isDataflowOpen && isDesignDatasetEditorRead && styles.checkboxDisabled}`}
-            disabled={isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled || isLoading}
+            disabled={isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled || isLoading || (addField && isTableLockedDueToData)}
             id={`${fieldId}_check_readOnly`}
             inputId={`${fieldId}_check_readOnly`}
             label="Default"
@@ -1073,7 +1075,8 @@ export const FieldDesigner = ({
               disabled={
                 !isNil(fieldDesignerState.fieldLinkValue) &&
                 !isEmpty(fieldDesignerState.fieldLinkValue) &&
-                isNil(fieldDesignerState.fieldLinkValue.name)
+                isNil(fieldDesignerState.fieldLinkValue.name) ||
+                isEditingEnabled
               }
               icon={
                 isNil(fieldDesignerState.fieldLinkValue) || isEmpty(fieldDesignerState.fieldLinkValue)
@@ -1149,7 +1152,9 @@ export const FieldDesigner = ({
                 className={`${styles.button} ${styles.deleteButton} ${
                   fieldPKReferenced ? styles.disabledDeleteButton : ''
                 } ${isDragging ? styles.dragAndDropActive : styles.dragAndDropInactive} ${
-                  isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled ? styles.linkDisabled : ''
+                  isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled || isTableLockedDueToData
+                    ? styles.linkDisabled
+                    : ''
                 }`}
                 draggable={true}
                 href="#"
@@ -1241,7 +1246,9 @@ export const FieldDesigner = ({
         className={styles.moveArrows}
         icon={AwesomeIcons(icon)}
         onClick={() => onMoveFieldUpDown(order)}
-        style={{ opacity: isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled ? 0.5 : 1 }}
+        style={{
+          opacity: isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled ? 0.5 : 1
+        }}
       />
     );
 
@@ -1253,7 +1260,9 @@ export const FieldDesigner = ({
             aria-label={resourcesContext.messages['moveField']}
             className={styles.dragAndDropIcon}
             icon={AwesomeIcons('move')}
-            style={{ opacity: isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled ? 0.5 : 1 }}
+            style={{
+              opacity: isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled ? 0.5 : 1
+            }}
           />
           {renderArrows('arrowUp', -1, 'moveUp')}
           {renderArrows('arrowDown', 2, 'moveDown')}
@@ -1282,7 +1291,9 @@ export const FieldDesigner = ({
               className={`${styles.button} ${styles.duplicateButton} ${
                 isDragging ? styles.dragAndDropActive : styles.dragAndDropInactive
               } ${
-                isDataflowOpen || isLoading || isDesignDatasetEditorRead || isEditingEnabled ? styles.linkDisabled : ''
+                isDataflowOpen || isLoading || isDesignDatasetEditorRead || isEditingEnabled || isTableLockedDueToData
+                  ? styles.linkDisabled
+                  : ''
               }`}
               data-for={duplicateButtonTooltipName}
               data-tip
@@ -1329,7 +1340,9 @@ export const FieldDesigner = ({
             className={`${isCodelistOrLink ? styles.withCodeListOrLink : ''} ${
               isDragging ? styles.dragAndDropActive : styles.dragAndDropInactive
             }`}
-            disabled={isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled || isLoading}
+            disabled={
+              isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled || isLoading || isTableLockedDueToData
+            }
             id={fieldName !== '' ? fieldName : 'newField'}
             maxLength={60}
             name={resourcesContext.messages['newFieldPlaceHolder']}
@@ -1365,6 +1378,7 @@ export const FieldDesigner = ({
             required={
               !isUndefined(fieldDesignerState.fieldValue) ? fieldDesignerState.fieldValue === '' : fieldName === ''
             }
+            tooltip={isTableLockedDueToData ? resourcesContext.messages['tableLockedDueToData'] : undefined}
             value={!isUndefined(fieldDesignerState.fieldValue) ? fieldDesignerState.fieldValue : fieldName}
           />
         </div>
@@ -1378,7 +1392,9 @@ export const FieldDesigner = ({
             autoFocus={false}
             className={`${isDragging ? styles.dragAndDropActive : styles.dragAndDropInactive}`}
             collapsedHeight={33}
-            disabled={isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled || isLoading}
+            disabled={
+              isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled || isLoading || (isTableLockedDueToData && addField)
+            }
             expandableOnClick={true}
             id={`${fieldName}_description`}
             key={fieldId}
@@ -1412,7 +1428,9 @@ export const FieldDesigner = ({
             className={`${styles.dropdownFieldType} ${isCodelistOrLink ? styles.withCodeListOrLink : ''} ${
               isDragging ? styles.dragAndDropActive : styles.dragAndDropInactive
             }`}
-            disabled={isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled || isLoading}
+            disabled={
+              isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled || isLoading || isTableLockedDueToData
+            }
             inputId={`${fieldName}_fieldType`}
             itemTemplate={fieldTypeTemplate}
             name={resourcesContext.messages['newFieldTypePlaceHolder']}
@@ -1429,6 +1447,7 @@ export const FieldDesigner = ({
             required={true}
             scrollHeight="450px"
             style={{ alignSelf: !fieldDesignerState.isEditing ? 'center' : 'auto', display: 'block' }}
+            tooltip={isTableLockedDueToData ? resourcesContext.messages['tableLockedDueToData'] : undefined}
             value={
               fieldDesignerState.fieldTypeValue !== ''
                 ? fieldDesignerState.fieldTypeValue
@@ -1458,6 +1477,7 @@ export const FieldDesigner = ({
               isIcebergCreated={isIcebergCreated}
               isLinkSelectorVisible={fieldDesignerState.isLinkSelectorVisible}
               isReferenceDataset={isReferenceDataset}
+              isTableLockedDueToData={isTableLockedDueToData}
               linkedTableConditional={fieldLinkedTableConditional}
               linkedTableLabel={fieldLinkedTableLabel}
               masterTableConditional={fieldMasterTableConditional}
@@ -1630,7 +1650,9 @@ export const FieldDesigner = ({
         className={`${styles.draggableFieldDiv} ${isDragging ? styles.disablePointerEvent : ''} ${
           isDragging && styles.fieldSeparatorDragging
         } fieldRow datasetSchema-fieldDesigner-help-step`}
-        draggable={isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled ? false : !addField}
+        draggable={
+          isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled || isTableLockedDueToData ? false : !addField
+        }
         onDragEnd={onFieldDragEnd}
         onDragEnter={onFieldDragEnter}
         onDragLeave={onFieldDragLeave}

--- a/frontend-service/src/views/DatasetDesigner/_components/TabsDesigner/_components/FieldsDesigner/_components/FieldDesigner/_components/LinkSelector/LinkSelector.jsx
+++ b/frontend-service/src/views/DatasetDesigner/_components/TabsDesigner/_components/FieldsDesigner/_components/FieldDesigner/_components/LinkSelector/LinkSelector.jsx
@@ -39,6 +39,7 @@ export const LinkSelector = ({
   isIcebergCreated,
   isLinkSelectorVisible,
   isReferenceDataset,
+  isTableLockedDueToData,
   linkedTableConditional,
   linkedTableLabel,
   masterTableConditional,
@@ -428,7 +429,7 @@ export const LinkSelector = ({
               datasetSchemas.map(datasetSchema => {
                 return (
                   <ListBox
-                    disabled={isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled}
+                    disabled={isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled || isTableLockedDueToData}
                     key={uniqueId('datasetSchema_')}
                     onChange={e => {
                       if (!isNil(e.value)) {
@@ -450,7 +451,7 @@ export const LinkSelector = ({
               appendTo={document.body}
               ariaLabel="linkedTableLabel"
               className={styles.fieldSelector}
-              disabled={isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled}
+              disabled={isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled || isTableLockedDueToData}
               inputId="linkedTableLabel"
               name={resourcesContext.messages['linkedTableLabel']}
               onChange={e =>
@@ -471,7 +472,7 @@ export const LinkSelector = ({
               appendTo={document.body}
               ariaLabel="masterTableConditional"
               className={styles.fieldSelector}
-              disabled={isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled}
+              disabled={isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled || isTableLockedDueToData}
               inputId="masterTableConditional"
               name={resourcesContext.messages['masterTableConditional']}
               onChange={e =>
@@ -490,7 +491,7 @@ export const LinkSelector = ({
               appendTo={document.body}
               ariaLabel="linkedTableConditional"
               className={styles.fieldSelector}
-              disabled={isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled}
+              disabled={isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled || isTableLockedDueToData}
               inputId="linkedTableConditional"
               name={resourcesContext.messages['linkedTableConditional']}
               onChange={e =>
@@ -511,7 +512,7 @@ export const LinkSelector = ({
             </span>
             <Checkbox
               checked={pkMustBeUsed}
-              disabled={isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled}
+              disabled={isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled || isTableLockedDueToData}
               id="pkMustBeUsed_check"
               inputId="pkMustBeUsed_check"
               label="Default"
@@ -523,7 +524,7 @@ export const LinkSelector = ({
             </span>
             <Checkbox
               checked={pkHasMultipleValues}
-              disabled={isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled}
+              disabled={isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled || isTableLockedDueToData}
               id="pkHasMultipleValues_check"
               inputId="pkHasMultipleValues_check"
               label="Default"
@@ -535,7 +536,7 @@ export const LinkSelector = ({
             </span>
             <Checkbox
               checked={ignoreCaseInLinks}
-              disabled={isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled}
+              disabled={isDataflowOpen || isDesignDatasetEditorRead || isEditingEnabled || isTableLockedDueToData}
               id="ignoreCaseInLinks_check"
               inputId="ignoreCaseInLinks_check"
               label="Default"

--- a/frontend-service/src/views/_components/TabView/TabView.jsx
+++ b/frontend-service/src/views/_components/TabView/TabView.jsx
@@ -36,6 +36,7 @@ export const TabView = ({
   isErrorDialogVisible,
   isDataflowOpen,
   isDesignDatasetEditorRead,
+  isTableLockedDueToData,
   onTabAdd,
   onTabAddCancel,
   onTabBlur,
@@ -215,7 +216,6 @@ export const TabView = ({
     );
     const id = `${idx}_header_${index}`;
     const ariaControls = `${idx}_content_${index}`;
-
     return (
       !(isDataflowOpen && isDesignDatasetEditorRead && tab.props.addTab) && (
         <Tab
@@ -244,6 +244,7 @@ export const TabView = ({
           isEditingEnabled={isEditingEnabled}
           isIcebergCreated={isIcebergCreated}
           isNavigationHidden={isNavigationHidden}
+          isTableLockedDueToData={tab.props.isTableLockedDueToData}
           key={id}
           leftIcon={tab.props.leftIcon}
           manualEdit={tab.props.manualEdit}
@@ -253,7 +254,7 @@ export const TabView = ({
           numberOfFields={tab.props.numberOfFields}
           onTabAddCancel={onTabAddCancel}
           onTabBlur={onTabBlur}
-          onTabDeleteClick={!isEditingEnabled ? onTabDeleteClicked : undefined}
+          onTabDeleteClick={!isEditingEnabled || !isTableLockedDueToData ? onTabDeleteClicked : undefined}
           onTabDragAndDrop={onTabDragAndDrop}
           onTabDragAndDropStart={onTabDragAndDropStart}
           onTabEditingHeader={onTabEditingHeader}

--- a/frontend-service/src/views/_components/TabView/_components/Tab/Tab.jsx
+++ b/frontend-service/src/views/_components/TabView/_components/Tab/Tab.jsx
@@ -52,6 +52,7 @@ export const Tab = ({
   isDesignDatasetEditorRead,
   isEditingEnabled,
   isIcebergCreated,
+  isTableLockedDueToData,
   index,
   initialTabIndexDrag,
   isNavigationHidden,
@@ -102,7 +103,7 @@ export const Tab = ({
   const tabRef = useRef();
 
   useEffect(() => {
-    if (!isEditingEnabled) {
+    if (!isEditingEnabled && !isTableLockedDueToData) {
       setMenu([
         {
           label: resourcesContext.messages['edit'],
@@ -125,7 +126,7 @@ export const Tab = ({
     } else {
       setMenu(undefined);
     }
-  }, [tableSchemaId, hasPKReferenced, isEditingEnabled]);
+  }, [tableSchemaId, hasPKReferenced, isEditingEnabled, isTableLockedDueToData]);
 
   useEffect(() => {
     if (!editingHeader) {
@@ -408,7 +409,7 @@ export const Tab = ({
   };
 
   const onTabDoubleClick = () => {
-    if (editable && !isEditingEnabled) {
+    if ((editable && !isEditingEnabled && !isTableLockedDueToData)) {
       if (!isUndefined(onTabEditingHeader)) {
         setEditingHeader(true);
         onTabEditingHeader(true);


### PR DESCRIPTION
Added a new feature in Design Mode in Big Data that whenever a table has data, certain actions are disabled. The user will have to delete the data before applying those changes. Added relevant messages and tooltips.

<img width="1744" height="690" alt="image" src="https://github.com/user-attachments/assets/d7c536c9-546b-4724-9975-233333a95f0a" />
