### PR TITLE
handle dremio unresponsive exception

### DIFF
--- a/common-utitlities/src/main/java/org/eea/datalake/service/impl/DremioHelperServiceImpl.java
+++ b/common-utitlities/src/main/java/org/eea/datalake/service/impl/DremioHelperServiceImpl.java
@@ -225,6 +225,11 @@ public class DremioHelperServiceImpl implements DremioHelperService {
                 throw new RuntimeException(e);
             }
         }
+        
+        if (folderId == null) {
+            throw new DremioApiException("Could not retrieve folder id for datasetId "
+                + s3PathResolver.getDatasetId() + " and folder " + folderName);
+        }
 
         try {
             dremioApiController.promote(token, folderId, requestBody);

--- a/common-utitlities/src/main/java/org/eea/datalake/service/impl/DremioHelperServiceImpl.java
+++ b/common-utitlities/src/main/java/org/eea/datalake/service/impl/DremioHelperServiceImpl.java
@@ -85,7 +85,14 @@ public class DremioHelperServiceImpl implements DremioHelperService {
 
     @Override
     public boolean checkFolderPromoted(S3PathResolver s3PathResolver, String folderName) {
-        DremioDirectoryItemsResponse directoryItems = getDirectoryItems(s3PathResolver, folderName);
+        DremioDirectoryItemsResponse directoryItems;
+        try {
+            directoryItems = getDirectoryItems(s3PathResolver, folderName);
+        } catch (Exception e) {
+            LOG.warn("Could not get directory items for folder {}", folderName, e);
+            return false;
+        }
+
         if (directoryItems!=null) {
             Integer itemPosition;
             if (S3_IMPORT_FILE_PATH.equals(s3PathResolver.getPath())) {
@@ -149,7 +156,14 @@ public class DremioHelperServiceImpl implements DremioHelperService {
     @Override
     public String getFolderId(S3PathResolver s3PathResolver, String folderName) {
         String folderId = null;
-        DremioDirectoryItemsResponse directoryItems = getDirectoryItems(s3PathResolver, folderName);
+        DremioDirectoryItemsResponse directoryItems;
+        try {
+            directoryItems = getDirectoryItems(s3PathResolver, folderName);
+        } catch (Exception e) {
+            LOG.warn("Could not retrieve directory items for datasetId" + s3PathResolver.getDatasetId(), e);
+            return null;
+        }
+
         if (directoryItems!=null) {
             Integer itemPosition;
             if (S3_IMPORT_FILE_PATH.equals(s3PathResolver.getPath())) {


### PR DESCRIPTION
 noticed looking at this bug the getdirectory items is creating rollback to data collection as the caller methods  checkfolderpromoted cannot  retry when dremio is unresponsive or refreshed on time, with this change we enable checkfolderpromoted to reply with false and the refreshtablemetadataandpromote and other caller methods to try again. we leave the get directory items  as is to log the exception . 