### PR TITLE
Exclude ORDER BY clause from big data count queries. Refs 302358

### DIFF
--- a/dataset-service/src/main/java/org/eea/dataset/service/helper/FileTreatmentHelper.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/helper/FileTreatmentHelper.java
@@ -968,7 +968,7 @@ public class FileTreatmentHelper implements DisposableBean {
         if (!filters.getQcCodes().isEmpty()) {
             qcCodes = new String[]{filters.getQcCodes()};
         }
-        StringBuilder filteredQuery = DataLakeDataRetrieverUtils.buildFilteredQuery(dataset, null, null, filters.getFieldValue(), fieldIdMap, filters.getLevelError(), qcCodes, validationTablePath);
+        StringBuilder filteredQuery = DataLakeDataRetrieverUtils.buildFilteredQuery(dataset, null, null, filters.getFieldValue(), fieldIdMap, filters.getLevelError(), qcCodes, validationTablePath, false);
         filteredQuery.append(" limit " + FILE_EXPORT_LIMIT);
         dataQuery.append(filteredQuery);
         return dataQuery;

--- a/dataset-service/src/main/java/org/eea/dataset/service/impl/DataCollectionDataRetrieverDL.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/impl/DataCollectionDataRetrieverDL.java
@@ -122,18 +122,21 @@ public class DataCollectionDataRetrieverDL implements DataLakeDataRetriever {
         fieldSchemaProviderCode.setName("data_provider_code");
         fieldIdMap.put("data_provider_code", fieldSchemaProviderCode);
 
-        StringBuilder filteredQuery = DataLakeDataRetrieverUtils.buildFilteredQuery(
-            dataset, fields, fieldSchemaId, fieldValue, fieldIdMap, levelError, qcCodes, null);
+        StringBuilder filteredCountQuery = DataLakeDataRetrieverUtils.buildFilteredQuery(
+            dataset, fields, fieldSchemaId, fieldValue, fieldIdMap, levelError, qcCodes, null, true);
 
         StringBuilder recordsCountQuery = new StringBuilder();
         recordsCountQuery
             .append("select count(record_id) from ")
             .append(s3Service.getTableDCAsFolderQueryPath(s3QueryResolver, S3_TABLE_NAME_DC_QUERY_PATH))
             .append(" t ")
-            .append(filteredQuery);
+            .append(filteredCountQuery);
 
         Long totalFilteredRecords = dremioJdbcTemplate.queryForObject(recordsCountQuery.toString(), Long.class);
         result.setTotalFilteredRecords(totalFilteredRecords);
+
+        StringBuilder filteredQuery = DataLakeDataRetrieverUtils.buildFilteredQuery(
+                dataset, fields, fieldSchemaId, fieldValue, fieldIdMap, levelError, qcCodes, null, false);
 
         pageable = DataLakeDataRetrieverUtils.calculatePageable(pageable, totalFilteredRecords);
         if (pageable != null) {

--- a/dataset-service/src/main/java/org/eea/dataset/service/impl/DatasetDataRetrieverDL.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/impl/DatasetDataRetrieverDL.java
@@ -107,14 +107,15 @@ public class DatasetDataRetrieverDL implements DataLakeDataRetriever {
                 validationS3PathResolver.setPath(S3_TABLE_AS_FOLDER_QUERY_PATH);
 
                 String validationTablePath = s3Service.getTableAsFolderQueryPath(validationS3PathResolver, S3_TABLE_AS_FOLDER_QUERY_PATH);
-                StringBuilder filteredQuery = DataLakeDataRetrieverUtils.buildFilteredQuery(dataset, fields, fieldSchemaId, fieldValue, fieldIdMap, levelError, qcCodes, validationTablePath);
+                StringBuilder filteredQuery = DataLakeDataRetrieverUtils.buildFilteredQuery(dataset, fields, fieldSchemaId, fieldValue, fieldIdMap, levelError, qcCodes, validationTablePath, false);
 
                 if (filteredQuery.toString().isEmpty() && levelError != null && levelError.length == 0) {
                     result.setTotalFilteredRecords(0L);
                     result.setTotalRecords(totalRecords);
                     result.setRecords(new ArrayList<>());
                 } else {
-                    recordsCountQuery.append(filteredQuery);
+                    StringBuilder filteredCountQuery = DataLakeDataRetrieverUtils.buildFilteredQuery(dataset, fields, fieldSchemaId, fieldValue, fieldIdMap, levelError, qcCodes, validationTablePath, true);
+                    recordsCountQuery.append(filteredCountQuery);
                     // Table path for metadata refresh and promotion.
                     String tablePathForRefresh;
                     if (REFERENCE.equals(dataset.getDatasetTypeEnum()) && !Boolean.TRUE.equals(s3PathResolver.getIsIcebergTable())) {

--- a/dataset-service/src/main/java/org/eea/dataset/service/impl/EuDatasetDataRetrieverDL.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/impl/EuDatasetDataRetrieverDL.java
@@ -121,18 +121,21 @@ public class EuDatasetDataRetrieverDL implements DataLakeDataRetriever {
         fieldSchemaProviderCode.setName("data_provider_code");
         fieldIdMap.put("data_provider_code", fieldSchemaProviderCode);
 
-        StringBuilder filteredQuery = DataLakeDataRetrieverUtils.buildFilteredQuery(
-            dataset, fields, fieldSchemaId, fieldValue, fieldIdMap, levelError, qcCodes, null);
+        StringBuilder filteredCountQuery = DataLakeDataRetrieverUtils.buildFilteredQuery(
+            dataset, fields, fieldSchemaId, fieldValue, fieldIdMap, levelError, qcCodes, null, true);
 
         StringBuilder recordsCountQuery = new StringBuilder();
         recordsCountQuery
             .append("select count(record_id) from ")
             .append(s3Service.getTableDCAsFolderQueryPath(s3QueryResolver, S3_TABLE_NAME_EU_QUERY_PATH))
             .append(" t ")
-            .append(filteredQuery);
+            .append(filteredCountQuery);
 
         Long totalFilteredRecords = dremioJdbcTemplate.queryForObject(recordsCountQuery.toString(), Long.class);
         result.setTotalFilteredRecords(totalFilteredRecords);
+
+        StringBuilder filteredQuery = DataLakeDataRetrieverUtils.buildFilteredQuery(
+                dataset, fields, fieldSchemaId, fieldValue, fieldIdMap, levelError, qcCodes, null, false);
 
         pageable = DataLakeDataRetrieverUtils.calculatePageable(pageable, totalFilteredRecords);
         if (pageable != null) {

--- a/dataset-service/src/main/java/org/eea/dataset/util/DataLakeDataRetrieverUtils.java
+++ b/dataset-service/src/main/java/org/eea/dataset/util/DataLakeDataRetrieverUtils.java
@@ -98,7 +98,7 @@ public class DataLakeDataRetrieverUtils {
                 dataQuery.append(" order by CASE when \"").append(sortField.getName()).append("\" like '' THEN '0000-00-00' ELSE CAST(\"").append(sortField.getName()).append("\" as DATE) END");
                 break;
             default:
-                dataQuery.append(" order by ").append(sortField.getName());
+                dataQuery.append(" order by \"").append(sortField.getName()).append("\"");
                 break;
         }
         dataQuery.append(sort[1].equals("1") ? " asc" : " desc");
@@ -138,7 +138,7 @@ public class DataLakeDataRetrieverUtils {
     }
 
     public static StringBuilder buildFilteredQuery(DataSetMetabaseVO dataset, String fields, String fieldSchemaId, String fieldValue, Map<String, FieldSchemaVO> fieldIdMap,
-                                            ErrorTypeEnum[] levelError, String[] qcCodes, String validationTablePath) {
+                                            ErrorTypeEnum[] levelError, String[] qcCodes, String validationTablePath, boolean forCount) {
         StringBuilder query = new StringBuilder();
         boolean levelErrorNotEmpty = levelError!=null && levelError.length>0 && levelError.length!=MAX_FILTERS;
         boolean qcCodesNotEmpty = qcCodes!=null && qcCodes.length>0;
@@ -154,8 +154,8 @@ public class DataLakeDataRetrieverUtils {
         if (qcCodesNotEmpty && validationTablePath!=null) {
             buildQcCodeFilterQuery(fieldValue, query, levelErrorNotEmpty, qcCodes, validationTablePath);
         }
-        //sorting
-        if (fields !=null) {
+        //sorting, do not apply for count query
+        if (fields !=null && !forCount) {
             buildSortQuery(fields, dataset.getDatasetSchema(), fieldIdMap, query);
         }
         return query;


### PR DESCRIPTION
Fix: exclude ORDER BY clause from count queries in buildFilteredQuery

Sorting was incorrectly applied to pagination count queries when querying Big Data Collections and Big Data EU Datasets via Dremio.
Since count queries return a single aggregated scalar, appending an ORDER BY clause is invalid and caused a VALIDATION ERROR in Dremio, resulting in a 500 on any column sort.

Added a `forCount` boolean parameter to `buildFilteredQuery` to conditionally skip sort clause generation when building count queries.