### PR TITLE
Bug 295327 perm fix attachment field issue

### DIFF
--- a/dataset-service/src/main/java/org/eea/dataset/service/DatasetService.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/DatasetService.java
@@ -420,6 +420,16 @@ public interface DatasetService {
   void updateAttachment(@DatasetId Long datasetId, String idField, String fileName, InputStream is)
       throws EEAException, IOException;
 
+  /**
+   * Ensures that the dataset schema contains the required dataset_value and table_value
+   * rows before records are created.
+   *
+   * @param datasetId the dataset id
+   * @param tableSchemaId the table schema id
+   * @throws EEAException if the metadata rows cannot be checked or repaired
+   */
+  void ensureDatasetAndTableValueExist(@DatasetId Long datasetId, String tableSchemaId)
+      throws EEAException;
 
   /**
    * Gets the field by id.

--- a/dataset-service/src/main/java/org/eea/dataset/service/DatasetService.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/DatasetService.java
@@ -428,8 +428,7 @@ public interface DatasetService {
    * @param tableSchemaId the table schema id
    * @throws EEAException if the metadata rows cannot be checked or repaired
    */
-  void ensureDatasetAndTableValueExist(@DatasetId Long datasetId, String tableSchemaId)
-      throws EEAException;
+  void ensureDatasetAndTableValueExist(@DatasetId Long datasetId, String tableSchemaId);
 
   /**
    * Gets the field by id.

--- a/dataset-service/src/main/java/org/eea/dataset/service/helper/UpdateRecordHelper.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/helper/UpdateRecordHelper.java
@@ -97,6 +97,8 @@ public class UpdateRecordHelper extends KafkaSenderUtils {
    */
   public void executeCreateProcess(final Long datasetId, List<RecordVO> records,
       String tableSchemaId) throws EEAException {
+    // Self-healing database records for attachments before inserting records #295327.
+    datasetService.ensureDatasetAndTableValueExist(datasetId, tableSchemaId);
     datasetService.insertRecords(datasetId, records, tableSchemaId);
     LOG.info("Records have been created for datasetId {}", datasetId);
     // now the view is not updated, update the check to false
@@ -124,6 +126,8 @@ public class UpdateRecordHelper extends KafkaSenderUtils {
   public void executeMultiCreateProcess(final Long datasetId, List<TableVO> tableRecords)
       throws EEAException {
     for (TableVO tableVO : tableRecords) {
+      // Self-healing database records for attachments before inserting records #295327.
+      datasetService.ensureDatasetAndTableValueExist(datasetId, tableVO.getIdTableSchema());
       datasetService.insertRecords(datasetId, tableVO.getRecords(), tableVO.getIdTableSchema());
     }
     LOG.info("PaM group save: Records have been created for datasetId {}", datasetId);

--- a/dataset-service/src/main/java/org/eea/dataset/service/impl/DatasetServiceImpl.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/impl/DatasetServiceImpl.java
@@ -1636,11 +1636,10 @@ public class DatasetServiceImpl implements DatasetService {
    */
   @Override
   @Transactional
-  public void ensureDatasetAndTableValueExist(Long datasetId, String tableSchemaId)
-      throws EEAException {
+  public void ensureDatasetAndTableValueExist(Long datasetId, String tableSchemaId) {
 
     if (datasetId == null || StringUtils.isBlank(tableSchemaId)) {
-      throw new EEAException("Unable to repair dataset metadata because datasetId or tableSchemaId is missing");
+      throw new IllegalStateException("Unable to repair dataset metadata because datasetId or tableSchemaId is missing");
     }
 
     TenantResolver.setTenantName(String.format(DATASET_ID, datasetId));
@@ -1652,7 +1651,7 @@ public class DatasetServiceImpl implements DatasetService {
       String datasetSchemaId = dataSetMetabaseRepository.findDatasetSchemaIdById(datasetId);
 
       if (StringUtils.isBlank(datasetSchemaId)) {
-        throw new EEAException("Unable to repair dataset metadata because datasetSchemaId is missing");
+        throw new IllegalStateException("Unable to repair dataset metadata because datasetSchemaId is missing");
       }
 
       datasetValue = new DatasetValue();

--- a/dataset-service/src/main/java/org/eea/dataset/service/impl/DatasetServiceImpl.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/impl/DatasetServiceImpl.java
@@ -90,8 +90,7 @@ import org.springframework.transaction.annotation.Propagation;
 import javax.transaction.Transactional;
 import java.io.*;
 import java.lang.reflect.InvocationTargetException;
-import java.sql.SQLException;
-import java.sql.Timestamp;
+import java.sql.*;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -1619,6 +1618,67 @@ public class DatasetServiceImpl implements DatasetService {
     updateCheckView(datasetId, false);
     // delete the temporary table from etlExport
     datasetRepository.removeTempEtlExport(datasetId);
+  }
+
+  /**
+   * For #295327.
+   * Ensures that the dataset schema contains the required dataset_value and table_value
+   * rows before records are created.
+   * In Transport, some datasets can reach the record creation flow while the dataset
+   * schema is missing the expected rows in dataset_value and/or table_value. When that
+   * happens, adding records with attachments can fail before the user ever reaches the
+   * attachment upload flow.
+   * This method is intentionally idempotent: if the rows already exist, nothing is changed.
+   *
+   * @param datasetId the dataset id
+   * @param tableSchemaId the table schema id where records are being created
+   * @throws EEAException if the metadata rows cannot be checked or repaired
+   */
+  @Override
+  @Transactional
+  public void ensureDatasetAndTableValueExist(Long datasetId, String tableSchemaId)
+      throws EEAException {
+
+    if (datasetId == null || StringUtils.isBlank(tableSchemaId)) {
+      throw new EEAException("Unable to repair dataset metadata because datasetId or tableSchemaId is missing");
+    }
+
+    TenantResolver.setTenantName(String.format(DATASET_ID, datasetId));
+
+    DatasetValue datasetValue = datasetRepository.findById(datasetId).orElse(null);
+
+    // Checks if dataset_value has a record and if not adds the missing one.
+    if (datasetValue == null) {
+      String datasetSchemaId = dataSetMetabaseRepository.findDatasetSchemaIdById(datasetId);
+
+      if (StringUtils.isBlank(datasetSchemaId)) {
+        throw new EEAException("Unable to repair dataset metadata because datasetSchemaId is missing");
+      }
+
+      datasetValue = new DatasetValue();
+      datasetValue.setId(datasetId);
+      datasetValue.setIdDatasetSchema(datasetSchemaId);
+      datasetValue.setViewUpdated(false);
+
+      datasetValue = datasetRepository.saveAndFlush(datasetValue);
+
+      LOG.info("Inserted missing dataset_value row for datasetId {} and datasetSchemaId {}",
+          datasetId, datasetSchemaId);
+    }
+
+    TableValue tableValue = tableRepository.findByIdTableSchema(tableSchemaId);
+
+    // Checks if table_value has a record and if not adds the missing one.
+    if (tableValue == null) {
+      tableValue = new TableValue();
+      tableValue.setIdTableSchema(tableSchemaId);
+      tableValue.setDatasetId(datasetValue);
+
+      tableRepository.saveAndFlush(tableValue);
+
+      LOG.info("Inserted missing table_value row for datasetId {} and tableSchemaId {}",
+          datasetId, tableSchemaId);
+    }
   }
 
   /**


### PR DESCRIPTION
https://taskman.eionet.europa.eu/issues/295327

Changed the approach that was described in the ticket. Instead of creating the database entries on attachmnet upload, the are now created on add record.

The helper ensures if the tables have the required records, if not, it creates them with the correct dataset schema id and table schema id