### PR TITLE
Bug #302205 Problem importing data to RN3

### DIFF
--- a/common-interfaces/src/main/java/org/eea/interfaces/vo/orchestrator/enums/JobInfoEnum.java
+++ b/common-interfaces/src/main/java/org/eea/interfaces/vo/orchestrator/enums/JobInfoEnum.java
@@ -53,6 +53,8 @@ public enum JobInfoEnum {
 
     WARNING_SOME_IMPORT_FILES_CONTAIN_WRONG_HEADERS("Some import files have headers that do not exactly match the field names of the reportnet tables. As a result those files were not imported."),
 
+    WARNING_GEOSPATIAL_DATA_FAILED_TO_BE_CONVERTED("Some geospatial data failed to be converted."),
+
     ERROR_IMPORT_FILES_CONTAIN_WRONG_HEADERS("Import files contain incorrect headers. Please ensure the headers in your files exactly match the field names of the corresponding tables."),
 
     ERROR_ETL_EXPORT_V4_CITUS("ETL Export v4 isn’t compatible with non–big data dataflows. Please use a supported export version."),

--- a/dataset-service/src/main/java/org/eea/dataset/service/impl/BigDataDatasetServiceImpl.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/impl/BigDataDatasetServiceImpl.java
@@ -803,7 +803,8 @@ public class BigDataDatasetServiceImpl implements BigDataDatasetService {
             }
 
             jobStatus = JobStatusEnum.CANCELED;
-        } else {
+        }
+        else {
             if (!isPreparationDataset) {
                 datasetMetabaseService.updateDatasetRunningStatus(importFileInDremioInfo.getDatasetId(),
                         DatasetRunningStatusEnum.IMPORTED);
@@ -905,6 +906,10 @@ public class BigDataDatasetServiceImpl implements BigDataDatasetService {
                             .datasetId(importFileInDremioInfo.getDatasetId()).fileName(importFileInDremioInfo.getFileName()).build();
                     kafkaSenderUtils.releaseNotificableKafkaEvent(EventType.IMPORT_WRONG_HEADERS_WARNING_EVENT,
                             value, notificationWarning);
+                }
+                if(warningMessage.equals(JobInfoEnum.WARNING_GEOSPATIAL_DATA_FAILED_TO_BE_CONVERTED.getValue(null))
+                        && !EEAErrorMessage.ERROR_IMPORT_EMPTY_FILES.equals(importFileInDremioInfo.getErrorMessage())){
+                    jobControllerZuul.updateJobInfo(jobId, JobInfoEnum.WARNING_GEOSPATIAL_DATA_FAILED_TO_BE_CONVERTED, null);
                 }
             }
         }

--- a/dataset-service/src/main/java/org/eea/dataset/service/impl/ParquetConverterServiceImpl.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/impl/ParquetConverterServiceImpl.java
@@ -905,8 +905,17 @@ public class ParquetConverterServiceImpl implements ParquetConverterService {
       } else if (expectedHeaderName.equals(LiteralConstants.PARQUET_PROVIDER_CODE_COLUMN_HEADER)) {
         row.add(importFileInDremioInfo.getDataProviderCode() != null ? importFileInDremioInfo.getDataProviderCode() : "");
       } else if (csvRecord.isMapped(expectedHeaderName)) {
-        row.add(spatialDataHandling.getGeoJsonEnums().contains(fieldType) ?
-            spatialDataHandling.convertToHEX(csvRecord.get(expectedHeaderName), lineNumber, spatialFieldInfo, expectedHeaderName) : csvRecord.get(expectedHeaderName));
+
+        if (spatialDataHandling.getGeoJsonEnums().contains(fieldType)) {
+          final String hexGeoJsonValue = spatialDataHandling.convertToHEX(csvRecord.get(expectedHeaderName), lineNumber, spatialFieldInfo, expectedHeaderName);
+          if (StringUtils.isBlank(hexGeoJsonValue)) {
+            importFileInDremioInfo.addDistinctWarningMessage(JobInfoEnum.WARNING_GEOSPATIAL_DATA_FAILED_TO_BE_CONVERTED.getValue(null));
+          }
+          row.add(hexGeoJsonValue);
+        }
+        else {
+          row.add(csvRecord.get(expectedHeaderName));
+        }
       } else {
         String headerWithBom = "\uFEFF" + expectedHeaderName;
         if(csvRecord.isMapped(headerWithBom)){

--- a/dataset-service/src/main/java/org/eea/dataset/service/model/ImportFileInDremioInfo.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/model/ImportFileInDremioInfo.java
@@ -54,4 +54,10 @@ public class ImportFileInDremioInfo {
         this.providerId = providerId;
         this.datasetId = datasetId;
     }
+
+    public void addDistinctWarningMessage(String warningMessage) {
+        if (!warningMessages.contains(warningMessage)) {
+            warningMessages.add(warningMessage);
+        }
+    }
 }


### PR DESCRIPTION
Use case: When a user imports a csv containing broken geospatial data, they fail to be converted and a blank value in left on the dataset table, while the import is considered a success. Users wanted to know about this failure and therefore a warning job info message should appear near the FINISHED status of the import job in the job monitoring page.