### PR TITLE
Scheduled task for Dremio health check. Refs #292616

### DIFF
--- a/common-interfaces/src/main/java/org/eea/interfaces/controller/dremio/controller/DremioApiController.java
+++ b/common-interfaces/src/main/java/org/eea/interfaces/controller/dremio/controller/DremioApiController.java
@@ -2,9 +2,11 @@ package org.eea.interfaces.controller.dremio.controller;
 
 import org.eea.interfaces.vo.dremio.*;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.ws.rs.core.MediaType;
+import java.util.Map;
 
 @FeignClient(name = "dremioClient", url = "${spring.cloud.openfeign.client.config.dremioClient.url}")
 public interface DremioApiController {
@@ -32,4 +34,19 @@ public interface DremioApiController {
 
     @GetMapping(value = "/api/v3/job/{id}/results", produces = MediaType.APPLICATION_JSON)
     Object sqlApiResults(@RequestHeader(value = "Authorization") String token, @PathVariable("id") String id);
+
+    /**
+     * Checks the Dremio server status.
+     *
+     * <p>Calls {@code GET apiv2/server_status} to verify that the Dremio HTTP server
+     * is reachable and operational. A successful response returns HTTP 200 with a
+     * JSON-quoted string body of {@code "\"OK\""}.
+     *
+     * @return a {@link ResponseEntity} containing the response body as a quoted JSON
+     *         string; HTTP 200 with body {@code "OK"} (after unquoting) indicates
+     *         healthy, any other status or body value indicates a problem
+     */
+    @GetMapping(value = "apiv2/server_status", produces = MediaType.APPLICATION_JSON)
+    ResponseEntity<String> getServerStatus();
+
 }

--- a/orchestrator-service/pom.xml
+++ b/orchestrator-service/pom.xml
@@ -26,6 +26,11 @@
       <artifactId>postgresql</artifactId>
       <version>42.6.1</version>
     </dependency>
+    <dependency>
+      <groupId>com.dremio.distribution</groupId>
+      <artifactId>dremio-jdbc-driver</artifactId>
+      <version>24.0.0-202302100528110223-3a169b7c</version>
+    </dependency>
   </dependencies>
   <distributionManagement>
     <snapshotRepository>
@@ -33,4 +38,10 @@
       <url>https://nexus-oami.altia.es/content/repositories/snapshots</url>
     </snapshotRepository>
   </distributionManagement>
+  <repositories>
+    <repository>
+      <id>dremio-free</id>
+      <url>https://maven.dremio.com/free/</url>
+    </repository>
+  </repositories>
 </project>

--- a/orchestrator-service/src/main/java/org/eea/orchestrator/configuration/DremioConfiguration.java
+++ b/orchestrator-service/src/main/java/org/eea/orchestrator/configuration/DremioConfiguration.java
@@ -1,0 +1,102 @@
+package org.eea.orchestrator.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import javax.sql.DataSource;
+
+/**
+ * Spring configuration for the Dremio JDBC integration.
+ *
+ * <p>Registers the following beans:
+ * <ul>
+ *   <li>{@link DataSource} — a {@link DriverManagerDataSource} configured with the Dremio
+ *       JDBC driver, URL, username, and password.</li>
+ *   <li>{@link JdbcTemplate} — a JDBC template backed by the Dremio datasource, used for
+ *       executing SQL queries against Dremio (e.g. the {@code SELECT 1} health check).</li>
+ * </ul>
+ *
+ * <p>HTTP connectivity to Dremio is handled separately via the {@code DremioApiController}
+ * Feign client, which reads its URL from
+ * {@code spring.cloud.openfeign.client.config.dremioClient.url}. No {@link
+ * org.springframework.web.client.RestTemplate} is needed here.
+ *
+ * <p>Required properties (set in {@code application.yml} or Consul):
+ * <ul>
+ *   <li>{@code dremio.url} — JDBC connection URL,
+ *       e.g. {@code jdbc:dremio:direct=dremio-host:31010}</li>
+ *   <li>{@code dremio.username} — Dremio username</li>
+ *   <li>{@code dremio.password} — Dremio password</li>
+ *   <li>{@code dremio.driver-class-name} — fully qualified JDBC driver class,
+ *       e.g. {@code com.dremio.jdbc.Driver}</li>
+ * </ul>
+ */
+@Configuration
+public class DremioConfiguration {
+
+    /**
+     * JDBC connection URL for the Dremio instance.
+     * Example: {@code jdbc:dremio:direct=dremio-host:31010}
+     */
+    @Value("${dremio.url}")
+    private String url;
+
+    /**
+     * Dremio username for JDBC authentication.
+     */
+    @Value("${dremio.username}")
+    private String username;
+
+    /**
+     * Dremio password for JDBC authentication.
+     */
+    @Value("${dremio.password}")
+    private String password;
+
+    /**
+     * Fully qualified class name of the Dremio JDBC driver.
+     * Example: {@code com.dremio.jdbc.Driver}
+     */
+    @Value("${dremio.driver-class-name}")
+    private String driver;
+
+    /**
+     * Creates and configures the Dremio {@link DataSource}.
+     *
+     * <p>Uses {@link DriverManagerDataSource} (non-pooling), which is appropriate here
+     * since connections are only opened during scheduled health-check runs rather than
+     * continuously.
+     *
+     * <p>Named explicitly as {@code "dremioDatasource"} to avoid conflicts with any other
+     * {@link DataSource} beans registered in the application context.
+     *
+     * @return a {@link DataSource} configured with the Dremio JDBC driver and credentials
+     */
+    @Bean(name = "dremioDatasource")
+    public DataSource dremioDatasource() {
+        DriverManagerDataSource dremioDataSource = new DriverManagerDataSource();
+        dremioDataSource.setDriverClassName(driver);
+        dremioDataSource.setUrl(url);
+        dremioDataSource.setUsername(username);
+        dremioDataSource.setPassword(password);
+        return dremioDataSource;
+    }
+
+    /**
+     * Creates a {@link JdbcTemplate} backed by the Dremio {@link DataSource}.
+     *
+     * <p>Named explicitly as {@code "dremioJdbcTemplate"} to avoid conflicts with any other
+     * {@link JdbcTemplate} beans registered in the application context (e.g. for the
+     * primary datasource). Consumers must use {@code @Qualifier("dremioJdbcTemplate")}
+     * when injecting this bean.
+     *
+     * @return a {@link JdbcTemplate} for executing queries against Dremio
+     */
+    @Bean(name = "dremioJdbcTemplate")
+    public JdbcTemplate dremioJdbcTemplate() {
+        return new JdbcTemplate(dremioDatasource());
+    }
+}

--- a/orchestrator-service/src/main/java/org/eea/orchestrator/configuration/DremioConfiguration.java
+++ b/orchestrator-service/src/main/java/org/eea/orchestrator/configuration/DremioConfiguration.java
@@ -75,7 +75,7 @@ public class DremioConfiguration {
      *
      * @return a {@link DataSource} configured with the Dremio JDBC driver and credentials
      */
-    @Bean(name = "dremioDatasource")
+    @Bean
     public DataSource dremioDatasource() {
         DriverManagerDataSource dremioDataSource = new DriverManagerDataSource();
         dremioDataSource.setDriverClassName(driver);
@@ -83,20 +83,5 @@ public class DremioConfiguration {
         dremioDataSource.setUsername(username);
         dremioDataSource.setPassword(password);
         return dremioDataSource;
-    }
-
-    /**
-     * Creates a {@link JdbcTemplate} backed by the Dremio {@link DataSource}.
-     *
-     * <p>Named explicitly as {@code "dremioJdbcTemplate"} to avoid conflicts with any other
-     * {@link JdbcTemplate} beans registered in the application context (e.g. for the
-     * primary datasource). Consumers must use {@code @Qualifier("dremioJdbcTemplate")}
-     * when injecting this bean.
-     *
-     * @return a {@link JdbcTemplate} for executing queries against Dremio
-     */
-    @Bean(name = "dremioJdbcTemplate")
-    public JdbcTemplate dremioJdbcTemplate() {
-        return new JdbcTemplate(dremioDatasource());
     }
 }

--- a/orchestrator-service/src/main/java/org/eea/orchestrator/scheduling/JobForCheckingDremioHealth.java
+++ b/orchestrator-service/src/main/java/org/eea/orchestrator/scheduling/JobForCheckingDremioHealth.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
  *       is reachable and returning HTTP 200.</li>
  *   <li><b>Functional SQL check:</b> submits a trivial query
  *       ({@code SELECT 1 ... LIMIT 1}) against the configured health-check table
- *       (property {@code dremio.health-check-table}) via the Dremio REST SQL API
+ *       (property {@code dremio.healthCheck.table}) via the Dremio REST SQL API
  *       ({@code POST /api/v3/sql}) through {@link DremioHelperService}, confirming that
  *       Dremio accepts and plans queries and that the table is addressable.</li>
  * </ol>
@@ -68,7 +68,7 @@ import java.util.stream.Collectors;
  * <ul>
  *   <li>{@code eea.keycloak.admin.user} - Keycloak admin username</li>
  *   <li>{@code eea.keycloak.admin.password} - Keycloak admin password</li>
- *   <li>{@code dremio.health-check-table} - dotted path of the table used by the
+ *   <li>{@code dremio.healthCheck.table} - dotted path of the table used by the
  *       functional SQL check, e.g.
  *       {@code rn3-dataset.rn3-dataset.test.liveness.1234}</li>
  * </ul>
@@ -127,7 +127,7 @@ public class JobForCheckingDremioHealth {
     @Value("${eea.communication.techEmailGroup}")
     private String techEmailGroup;
 
-    @Value("${dremio.health-check-table}")
+    @Value("${dremio.healthCheck.table}")
     private String healthCheckTable;
 
     /**

--- a/orchestrator-service/src/main/java/org/eea/orchestrator/scheduling/JobForCheckingDremioHealth.java
+++ b/orchestrator-service/src/main/java/org/eea/orchestrator/scheduling/JobForCheckingDremioHealth.java
@@ -65,7 +65,7 @@ import java.util.Map;
  *
  * <p>Optional configuration properties (with defaults):
  * <ul>
- *   <li>{@code dremio.health-check.slow-threshold-ms} - maximum acceptable cycle duration
+ *   <li>{@code dremio.healthCheck.slowThresholdMs} - maximum acceptable cycle duration
  *       in ms before a slowness warning is raised (default: {@code 5000})</li>
  * </ul>
  *
@@ -86,7 +86,7 @@ public class JobForCheckingDremioHealth {
      * If the combined time of both checks exceeds this value, a slowness warning is raised.
      * Defaults to 5000 ms (5 seconds).
      */
-    @Value("${dremio.health-check.slow-threshold-ms:5000}")
+    @Value("${dremio.healthCheck.slowThresholdMs:5000}")
     private long slowThresholdMs;
 
     /**

--- a/orchestrator-service/src/main/java/org/eea/orchestrator/scheduling/JobForCheckingDremioHealth.java
+++ b/orchestrator-service/src/main/java/org/eea/orchestrator/scheduling/JobForCheckingDremioHealth.java
@@ -1,0 +1,345 @@
+package org.eea.orchestrator.scheduling;
+
+import feign.FeignException;
+import org.eea.interfaces.controller.communication.EmailController;
+import org.eea.interfaces.controller.dremio.controller.DremioApiController;
+import org.eea.interfaces.controller.ums.UserManagementController;
+import org.eea.interfaces.vo.communication.EmailVO;
+import org.eea.interfaces.vo.ums.TokenVO;
+import org.eea.orchestrator.configuration.DremioConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Scheduled job that monitors the availability and responsiveness of the Dremio instance.
+ *
+ * <p>This job runs every 10 minutes and performs a two-step health check:
+ * <ol>
+ *   <li><b>Server status check:</b> calls {@code GET apiv2/server_status} via the
+ *       {@link DremioApiController} Feign client to verify that the Dremio HTTP server
+ *       is reachable and returning HTTP 200.</li>
+ *   <li><b>Functional SQL check:</b> executes a {@code SELECT 1} query via JDBC to confirm
+ *       that the Dremio query engine is operational end-to-end.</li>
+ * </ol>
+ *
+ * <p>Step 2 is only executed if step 1 succeeds. If either step fails, the error is logged
+ * and an email notification is sent via {@link EmailController.EmailControllerZuul}.
+ * Additionally, if the total cycle duration exceeds the configured slow-response threshold,
+ * a warning is logged and an email is sent even if both checks passed.
+ *
+ * <p>This job is intentionally silent on healthy runs - it only produces output when
+ * something is wrong.
+ *
+ * <p>HTTP connectivity to Dremio is handled by the {@link DremioApiController} Feign client,
+ * which reads its base URL from
+ * {@code spring.cloud.openfeign.client.config.dremioClient.url}. No additional URL
+ * configuration is needed in this job.
+ *
+ * <p>Authentication is handled by obtaining a Keycloak token for the configured admin user
+ * via {@link UserManagementController.UserManagementControllerZull} and registering it in
+ * the Spring {@link SecurityContextHolder} before each run, following the same pattern
+ * used by other jobs in this package.
+ *
+ * <p>Required configuration properties:
+ * <ul>
+ *   <li>{@code eea.keycloak.admin.user} - Keycloak admin username</li>
+ *   <li>{@code eea.keycloak.admin.password} - Keycloak admin password</li>
+ * </ul>
+ *
+ * <p>Optional configuration properties (with defaults):
+ * <ul>
+ *   <li>{@code dremio.health-check.slow-threshold-ms} - maximum acceptable cycle duration
+ *       in ms before a slowness warning is raised (default: {@code 5000})</li>
+ * </ul>
+ *
+ * @see DremioConfiguration
+ * @see DremioApiController
+ */
+@Import(DremioConfiguration.class)
+@Component
+public class JobForCheckingDremioHealth {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JobForCheckingDremioHealth.class);
+
+    /** Bearer token prefix used when populating the Spring security context. */
+    private static final String BEARER = "Bearer ";
+
+    /**
+     * Maximum acceptable duration (ms) for the full health check cycle.
+     * If the combined time of both checks exceeds this value, a slowness warning is raised.
+     * Defaults to 5000 ms (5 seconds).
+     */
+    @Value("${dremio.health-check.slow-threshold-ms:5000}")
+    private long slowThresholdMs;
+
+    /**
+     * Keycloak admin username used to authenticate before each health check run.
+     * Injected from {@code eea.keycloak.admin.user}.
+     */
+    @Value("${eea.keycloak.admin.user}")
+    private String adminUser;
+
+    /**
+     * Keycloak admin password used to authenticate before each health check run.
+     * Injected from {@code eea.keycloak.admin.password}.
+     */
+    @Value("${eea.keycloak.admin.password}")
+    private String adminPass;
+
+    /**
+     * JDBC template configured for the Dremio datasource.
+     * Used in step 2 to execute the {@code SELECT 1} functional check.
+     * Qualified as {@code "dremioJdbcTemplate"} to avoid conflicts with other datasource beans.
+     */
+    private final JdbcTemplate dremioJdbcTemplate;
+
+    /**
+     * Feign client for Dremio REST API calls.
+     * Used in step 1 to call {@code GET apiv2/server_status}.
+     * Its base URL is configured via
+     * {@code spring.cloud.openfeign.client.config.dremioClient.url}.
+     */
+    private final DremioApiController dremioApiController;
+
+    /**
+     * Feign client for sending email notifications via the communication microservice.
+     * Invoked when a health check step fails or the slowness threshold is exceeded.
+     */
+    private final EmailController.EmailControllerZuul emailControllerZuul;
+
+    /**
+     * Feign client for the user management microservice.
+     * Used to obtain a Keycloak access token for the admin user before each run.
+     */
+    private final UserManagementController.UserManagementControllerZull userManagementControllerZull;
+
+    /**
+     * Constructs the job with all required dependencies via constructor injection.
+     *
+     * @param dremioJdbcTemplate           JDBC template for the Dremio datasource
+     * @param dremioApiController          Feign client for Dremio REST API calls
+     * @param emailControllerZuul          Feign client for sending email notifications
+     * @param userManagementControllerZull Feign client for obtaining Keycloak tokens
+     */
+    public JobForCheckingDremioHealth(
+            @Qualifier("dremioJdbcTemplate") JdbcTemplate dremioJdbcTemplate,
+            DremioApiController dremioApiController,
+            EmailController.EmailControllerZuul emailControllerZuul,
+            UserManagementController.UserManagementControllerZull userManagementControllerZull) {
+        this.dremioJdbcTemplate = dremioJdbcTemplate;
+        this.dremioApiController = dremioApiController;
+        this.emailControllerZuul = emailControllerZuul;
+        this.userManagementControllerZull = userManagementControllerZull;
+    }
+
+    /**
+     * Registers the health check task with a dedicated scheduler after bean construction.
+     *
+     * <p>A {@link ThreadPoolTaskScheduler} is created and the job is scheduled using the
+     * cron expression {@code 0 *{@literal /}10 * * * *}, which fires on every 10-minute
+     * boundary of the clock (e.g. 00:00, 00:10, 00:20, ...).
+     */
+    @PostConstruct
+    private void init() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.initialize();
+        scheduler.schedule(this::checkDremioHealth, new CronTrigger("0 */10 * * * *"));
+    }
+
+    /**
+     * Main health check entry point, invoked every 10 minutes by the scheduler.
+     *
+     * <p>Execution flow:
+     * <ol>
+     *   <li>Records the start time for slowness detection.</li>
+     *   <li>Authenticates as the configured Keycloak admin user.</li>
+     *   <li>Calls {@link #isServerStatusOk()} - exits early on failure.</li>
+     *   <li>Calls {@link #isSelectOneOk()} - exits early on failure.</li>
+     *   <li>Checks total elapsed time; logs a warning and sends an email if it exceeds
+     *       {@code slowThresholdMs}.</li>
+     * </ol>
+     *
+     * <p>A top-level {@code catch} prevents any unhandled exception from silently killing
+     * the scheduler thread.
+     */
+    public void checkDremioHealth() {
+        try {
+            LOG.info("Running scheduled task checkDremioHealth");
+
+            // Captured here so elapsed time covers both checks
+            Instant start = Instant.now();
+
+            authenticateAsAdmin();
+
+            // Step 1 - server reachability via Feign REST client
+            if (!isServerStatusOk()) {
+                return;
+            }
+
+            // Step 2 - query engine functionality via JDBC
+            if (!isSelectOneOk()) {
+                return;
+            }
+
+            // Step 3 - slowness detection across the full cycle
+            long elapsedMs = Duration.between(start, Instant.now()).toMillis();
+            if (elapsedMs > slowThresholdMs) {
+                String message = String.format(
+                        "Dremio health-check passed but was SLOW - elapsed %d ms (threshold %d ms).",
+                        elapsedMs, slowThresholdMs);
+                LOG.warn(message);
+                notifyByEmail("Dremio Health Warning - Slow Response", message);
+            }
+
+        } catch (Exception e) {
+            LOG.error("Error while running scheduled task checkDremioHealth", e);
+        }
+    }
+
+    /**
+     * Performs step 1 of the health check by calling {@code GET apiv2/server_status}
+     * via the {@link DremioApiController} Feign client.
+     *
+     * <p>Verifies that the Dremio HTTP server is reachable and returning HTTP 200.
+     * The response body is not validated - a 200 status is considered sufficient evidence
+     * that the server process is running and accepting connections.
+     *
+     * <p>Failure cases handled:
+     * <ul>
+     *   <li>Non-200 HTTP status - logs error, sends email, returns {@code false}.</li>
+     *   <li>{@link FeignException} - covers all Feign failure scenarios including 4xx/5xx
+     *       responses, timeouts, and connection refused. {@link FeignException#status()}
+     *       is included in the log message; a value of {@code -1} indicates no response
+     *       was received (e.g. connection refused or timeout).</li>
+     *   <li>Any other unexpected exception - logs error, sends email, returns
+     *       {@code false}.</li>
+     * </ul>
+     *
+     * @return {@code true} if Dremio returned HTTP 200; {@code false} on any failure
+     */
+    private boolean isServerStatusOk() {
+        try {
+            ResponseEntity<String> response = dremioApiController.getServerStatus();
+
+            if (!HttpStatus.OK.equals(response.getStatusCode())) {
+                String msg = "Dremio server_status returned unexpected HTTP " + response.getStatusCode();
+                LOG.error(msg);
+                notifyByEmail("Dremio Health Alert - Unhealthy Status", msg);
+                return false;
+            }
+
+            // Response body should be "OK"
+            String body = response.getBody() != null ? response.getBody().replace("\"", "").trim() : "";
+            if (!"OK".equalsIgnoreCase(body)) {
+                String msg = "Dremio server_status returned unexpected body: " + response.getBody();
+                LOG.error(msg);
+                notifyByEmail("Dremio Health Alert - Unhealthy Status", msg);
+                return false;
+            }
+            return true;
+
+        } catch (FeignException e) {
+            String msg = "Dremio server_status unreachable or failed with status "
+                    + e.status() + ": " + e.getMessage();
+            LOG.error(msg, e);
+            notifyByEmail("Dremio Health Alert - Unreachable", msg);
+            return false;
+
+        } catch (Exception e) {
+            String msg = "Unexpected error calling Dremio server_status: " + e.getMessage();
+            LOG.error(msg, e);
+            notifyByEmail("Dremio Health Alert - Unexpected Error", msg);
+            return false;
+        }
+    }
+
+    /**
+     * Performs step 2 of the health check by executing {@code SELECT 1} via JDBC.
+     *
+     * <p>Verifies that the Dremio query engine is operational end-to-end. A successful
+     * result confirms that Dremio accepted, planned, and executed a trivial query.
+     * This step is only reached if {@link #isServerStatusOk()} returned {@code true}.
+     *
+     * <p>Failure cases handled:
+     * <ul>
+     *   <li>{@link DataAccessException} (JDBC / SQL error) - logs error, sends email,
+     *       returns {@code false}.</li>
+     *   <li>Any other unexpected exception - logs error, sends email, returns
+     *       {@code false}.</li>
+     * </ul>
+     *
+     * @return {@code true} if {@code SELECT 1} executed successfully; {@code false} on any failure
+     */
+    private boolean isSelectOneOk() {
+        try {
+            dremioJdbcTemplate.queryForObject("SELECT 1", Integer.class);
+            return true;
+
+        } catch (DataAccessException e) {
+            String msg = "Dremio SELECT 1 failed via JDBC: " + e.getMessage();
+            LOG.error(msg, e);
+            notifyByEmail("Dremio Health Alert - SQL Check Failed", msg);
+            return false;
+
+        } catch (Exception e) {
+            String msg = "Unexpected error running Dremio SELECT 1: " + e.getMessage();
+            LOG.error(msg, e);
+            notifyByEmail("Dremio Health Alert - SQL Error", msg);
+            return false;
+        }
+    }
+
+    /**
+     * Authenticates as the configured Keycloak admin user and stores the resulting
+     * token in the Spring {@link SecurityContextHolder}.
+     *
+     * <p>This ensures that outbound Feign calls (e.g. to the email microservice) carry
+     * a valid Bearer token, following the same pattern used by other scheduled jobs
+     * in this package.
+     */
+    private void authenticateAsAdmin() {
+        TokenVO tokenVo = userManagementControllerZull.generateToken(adminUser, adminPass);
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(
+                        adminUser, BEARER + tokenVo.getAccessToken(), null);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    /**
+     * Sends an email notification via the communication microservice.
+     *
+     * <p>This method is intentionally non-throwing - any failure to deliver the
+     * notification is logged separately and never allowed to propagate, ensuring that
+     * email delivery issues do not mask the original health check problem.
+     *
+     * @param subject the email subject line describing the alert type
+     * @param body    the email body containing the detailed error or warning message
+     */
+    private void notifyByEmail(String subject, String body) {
+        try {
+            EmailVO emailVO = new EmailVO();
+            emailVO.setSubject(subject);
+            emailVO.setText(body);
+            emailControllerZuul.sendMessage(emailVO);
+        } catch (Exception e) {
+            LOG.error("Failed to send Dremio health-check notification email: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/orchestrator-service/src/main/java/org/eea/orchestrator/scheduling/JobForCheckingDremioHealth.java
+++ b/orchestrator-service/src/main/java/org/eea/orchestrator/scheduling/JobForCheckingDremioHealth.java
@@ -1,21 +1,23 @@
 package org.eea.orchestrator.scheduling;
 
 import feign.FeignException;
+import org.eea.datalake.service.DremioHelperService;
+import org.eea.exception.DremioApiException;
 import org.eea.interfaces.controller.communication.EmailController;
 import org.eea.interfaces.controller.dremio.controller.DremioApiController;
 import org.eea.interfaces.controller.ums.UserManagementController;
 import org.eea.interfaces.vo.communication.EmailVO;
+import org.eea.interfaces.vo.dremio.DremioAuthResponse;
+import org.eea.interfaces.vo.dremio.DremioCredentials;
+import org.eea.interfaces.vo.dremio.DremioSqlRequestBody;
 import org.eea.interfaces.vo.ums.TokenVO;
 import org.eea.orchestrator.configuration.DremioConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Import;
-import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -25,7 +27,9 @@ import org.springframework.stereotype.Component;
 import javax.annotation.PostConstruct;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Map;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Scheduled job that monitors the availability and responsiveness of the Dremio instance.
@@ -35,8 +39,11 @@ import java.util.Map;
  *   <li><b>Server status check:</b> calls {@code GET apiv2/server_status} via the
  *       {@link DremioApiController} Feign client to verify that the Dremio HTTP server
  *       is reachable and returning HTTP 200.</li>
- *   <li><b>Functional SQL check:</b> executes a {@code SELECT 1} query via JDBC to confirm
- *       that the Dremio query engine is operational end-to-end.</li>
+ *   <li><b>Functional SQL check:</b> submits a trivial query
+ *       ({@code SELECT 1 ... LIMIT 1}) against the configured health-check table
+ *       (property {@code dremio.health-check-table}) via the Dremio REST SQL API
+ *       ({@code POST /api/v3/sql}) through {@link DremioHelperService}, confirming that
+ *       Dremio accepts and plans queries and that the table is addressable.</li>
  * </ol>
  *
  * <p>Step 2 is only executed if step 1 succeeds. If either step fails, the error is logged
@@ -61,6 +68,9 @@ import java.util.Map;
  * <ul>
  *   <li>{@code eea.keycloak.admin.user} - Keycloak admin username</li>
  *   <li>{@code eea.keycloak.admin.password} - Keycloak admin password</li>
+ *   <li>{@code dremio.health-check-table} - dotted path of the table used by the
+ *       functional SQL check, e.g.
+ *       {@code rn3-dataset.rn3-dataset.test.liveness.1234}</li>
  * </ul>
  *
  * <p>Optional configuration properties (with defaults):
@@ -72,7 +82,7 @@ import java.util.Map;
  * @see DremioConfiguration
  * @see DremioApiController
  */
-@Import(DremioConfiguration.class)
+@Import({DremioConfiguration.class})
 @Component
 public class JobForCheckingDremioHealth {
 
@@ -80,6 +90,13 @@ public class JobForCheckingDremioHealth {
 
     /** Bearer token prefix used when populating the Spring security context. */
     private static final String BEARER = "Bearer ";
+    public static String token = null;
+
+    @Value("${dremio.username}")
+    private String dremioUsername;
+
+    @Value("${dremio.password}")
+    private String dremioPassword;
 
     /**
      * Maximum acceptable duration (ms) for the full health check cycle.
@@ -104,17 +121,18 @@ public class JobForCheckingDremioHealth {
     private String adminPass;
 
     /**
-     * JDBC template configured for the Dremio datasource.
-     * Used in step 2 to execute the {@code SELECT 1} functional check.
-     * Qualified as {@code "dremioJdbcTemplate"} to avoid conflicts with other datasource beans.
+     * The email address (or comma-separated list of addresses) for the recipient group,
+     * injected from the application property {@code eea.communication.techEmailGroup}.
      */
-    private final JdbcTemplate dremioJdbcTemplate;
+    @Value("${eea.communication.techEmailGroup}")
+    private String techEmailGroup;
+
+    @Value("${dremio.health-check-table}")
+    private String healthCheckTable;
 
     /**
      * Feign client for Dremio REST API calls.
      * Used in step 1 to call {@code GET apiv2/server_status}.
-     * Its base URL is configured via
-     * {@code spring.cloud.openfeign.client.config.dremioClient.url}.
      */
     private final DremioApiController dremioApiController;
 
@@ -133,17 +151,14 @@ public class JobForCheckingDremioHealth {
     /**
      * Constructs the job with all required dependencies via constructor injection.
      *
-     * @param dremioJdbcTemplate           JDBC template for the Dremio datasource
      * @param dremioApiController          Feign client for Dremio REST API calls
      * @param emailControllerZuul          Feign client for sending email notifications
      * @param userManagementControllerZull Feign client for obtaining Keycloak tokens
      */
     public JobForCheckingDremioHealth(
-            @Qualifier("dremioJdbcTemplate") JdbcTemplate dremioJdbcTemplate,
             DremioApiController dremioApiController,
             EmailController.EmailControllerZuul emailControllerZuul,
             UserManagementController.UserManagementControllerZull userManagementControllerZull) {
-        this.dremioJdbcTemplate = dremioJdbcTemplate;
         this.dremioApiController = dremioApiController;
         this.emailControllerZuul = emailControllerZuul;
         this.userManagementControllerZull = userManagementControllerZull;
@@ -185,7 +200,6 @@ public class JobForCheckingDremioHealth {
 
             // Captured here so elapsed time covers both checks
             Instant start = Instant.now();
-
             authenticateAsAdmin();
 
             // Step 1 - server reachability via Feign REST client
@@ -193,7 +207,7 @@ public class JobForCheckingDremioHealth {
                 return;
             }
 
-            // Step 2 - query engine functionality via JDBC
+            // Step 2 - query engine functionality via the REST SQL API against a specific table
             if (!isSelectOneOk()) {
                 return;
             }
@@ -271,38 +285,44 @@ public class JobForCheckingDremioHealth {
     }
 
     /**
-     * Performs step 2 of the health check by executing {@code SELECT 1} via JDBC.
+     * Performs step 2 of the health check by executing a trivial query against a real
+     * table via the Dremio REST API ({@code POST /api/v3/sql}).
      *
-     * <p>Verifies that the Dremio query engine is operational end-to-end. A successful
-     * result confirms that Dremio accepted, planned, and executed a trivial query.
-     * This step is only reached if {@link #isServerStatusOk()} returned {@code true}.
-     *
-     * <p>Failure cases handled:
-     * <ul>
-     *   <li>{@link DataAccessException} (JDBC / SQL error) - logs error, sends email,
-     *       returns {@code false}.</li>
-     *   <li>Any other unexpected exception - logs error, sends email, returns
-     *       {@code false}.</li>
-     * </ul>
-     *
-     * @return {@code true} if {@code SELECT 1} executed successfully; {@code false} on any failure
+     * @return {@code true} if the query was accepted and a job id was returned;
+     *         {@code false} on any failure
      */
     private boolean isSelectOneOk() {
         try {
-            dremioJdbcTemplate.queryForObject("SELECT 1", Integer.class);
+            String sql = buildHealthQuery(healthCheckTable);
+            String jobId = executeSqlStatement(sql);
+            if (jobId == null || jobId.isBlank()) {
+                String msg = "Dremio health query was submitted but no job id was returned. SQL: " + sql;
+                LOG.error(msg);
+                notifyByEmail("Dremio Health Alert - SQL Check Failed", msg);
+                return false;
+            }
             return true;
-
-        } catch (DataAccessException e) {
-            String msg = "Dremio SELECT 1 failed via JDBC: " + e.getMessage();
-            LOG.error(msg, e);
-            notifyByEmail("Dremio Health Alert - SQL Check Failed", msg);
-            return false;
-
         } catch (Exception e) {
-            String msg = "Unexpected error running Dremio SELECT 1: " + e.getMessage();
+            String msg = "Unexpected error running Dremio health query: " + e.getMessage();
             LOG.error(msg, e);
             notifyByEmail("Dremio Health Alert - SQL Error", msg);
             return false;
+        }
+    }
+
+    public String executeSqlStatement(String sqlStatement) throws DremioApiException {
+        DremioSqlRequestBody dremioSqlRequestBody = new DremioSqlRequestBody(sqlStatement);
+        try {
+            return dremioApiController.sqlQuery(token, dremioSqlRequestBody).getId();
+        } catch (FeignException e) {
+            //retry call if there is an authentication error
+            String errorMessage = "Could not execute sql statement " + sqlStatement;
+            if (e.status() == HttpStatus.UNAUTHORIZED.value()) {
+                token = this.getAuthToken();
+                return dremioApiController.sqlQuery(token, dremioSqlRequestBody).getId();
+            } else {
+                throw new DremioApiException(errorMessage);
+            }
         }
     }
 
@@ -322,6 +342,25 @@ public class JobForCheckingDremioHealth {
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
+    private String buildHealthQuery(String tablePath) {
+        String[] parts = tablePath.split("\\.");
+        StringBuilder sb = new StringBuilder("SELECT 1 FROM ");
+        for (int i = 0; i < parts.length; i++) {
+            sb.append('"').append(parts[i].replace("\"", "\"\"")).append('"');
+            if (i < parts.length - 1) {
+                sb.append(".");
+            }
+        }
+        sb.append(" LIMIT 1");
+        return sb.toString();
+    }
+
+    public String getAuthToken() {
+        DremioCredentials dremioCredentials = new DremioCredentials(dremioUsername, dremioPassword);
+        DremioAuthResponse response = dremioApiController.login(dremioCredentials);
+        return BEARER + response.getToken();
+    }
+
     /**
      * Sends an email notification via the communication microservice.
      *
@@ -335,6 +374,7 @@ public class JobForCheckingDremioHealth {
     private void notifyByEmail(String subject, String body) {
         try {
             EmailVO emailVO = new EmailVO();
+            emailVO.setTo(resolveRecipients(techEmailGroup));
             emailVO.setSubject(subject);
             emailVO.setText(body);
             emailControllerZuul.sendMessage(emailVO);
@@ -342,4 +382,18 @@ public class JobForCheckingDremioHealth {
             LOG.error("Failed to send Dremio health-check notification email: {}", e.getMessage(), e);
         }
     }
+
+    /**
+     * Resolves a comma-separated string of email addresses into a {@link List}.
+     *
+     * <p>Trims whitespace from each entry and filters out any blank values,
+     * making it safe for use with loosely formatted property values.
+     */
+    private List<String> resolveRecipients(String emailGroupValue) {
+        return Arrays.stream(emailGroupValue.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isBlank())
+                .collect(Collectors.toList());
+    }
+
 }

--- a/orchestrator-service/src/test/java/org/eea/orchestrator/scheduling/JobForCheckingDremioHealthTest.java
+++ b/orchestrator-service/src/test/java/org/eea/orchestrator/scheduling/JobForCheckingDremioHealthTest.java
@@ -1,0 +1,209 @@
+package org.eea.orchestrator.scheduling;
+
+import feign.FeignException;
+import org.eea.interfaces.controller.communication.EmailController;
+import org.eea.interfaces.controller.dremio.controller.DremioApiController;
+import org.eea.interfaces.controller.ums.UserManagementController;
+import org.eea.interfaces.vo.communication.EmailVO;
+import org.eea.interfaces.vo.ums.TokenVO;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.*;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+
+/**
+ * Unit tests for {@link JobForCheckingDremioHealth}.
+ *
+ * <p>Covers all execution paths of the two-step health check:
+ * <ul>
+ *   <li>Step 1 - {@code GET apiv2/server_status} via Feign: healthy, unhealthy HTTP status,
+ *       unexpected body, {@link FeignException}, unexpected exception.</li>
+ *   <li>Step 2 - {@code SELECT 1} via JDBC: healthy,
+ *       {@link org.springframework.dao.DataAccessException}, unexpected exception.</li>
+ *   <li>Slowness detection - elapsed time exceeds the configured threshold.</li>
+ *   <li>Email notification resilience - delivery failures do not propagate.</li>
+ * </ul>
+ *
+ * <p>All dependencies are mocked via Mockito. {@code FeignException} is mocked directly
+ * following the same pattern used in other Dremio-related tests in this project.
+ */
+public class JobForCheckingDremioHealthTest {
+
+    @InjectMocks
+    private JobForCheckingDremioHealth job;
+
+    @Mock
+    private JdbcTemplate dremioJdbcTemplate;
+
+    @Mock
+    private DremioApiController dremioApiController;
+
+    @Mock
+    private EmailController.EmailControllerZuul emailControllerZuul;
+
+    @Mock
+    private UserManagementController.UserManagementControllerZull userManagementControllerZull;
+
+    @Mock
+    private FeignException feignException;
+
+    @Before
+    public void initMocks() {
+        MockitoAnnotations.openMocks(this);
+
+        // Inject @Value fields that Spring would normally populate
+        ReflectionTestUtils.setField(job, "slowThresholdMs", 5000L);
+        ReflectionTestUtils.setField(job, "adminUser", "admin");
+        ReflectionTestUtils.setField(job, "adminPass", "password");
+
+        // Stub admin authentication for all tests
+        TokenVO token = new TokenVO();
+        token.setAccessToken("test-token");
+        Mockito.when(userManagementControllerZull.generateToken(anyString(), anyString()))
+                .thenReturn(token);
+    }
+
+    /**
+     * Both steps pass - no emails sent.
+     */
+    @Test
+    public void checkDremioHealth_bothStepsOk_noEmailSent() {
+        Mockito.when(dremioApiController.getServerStatus())
+                .thenReturn(ResponseEntity.ok("\"OK\""));
+        Mockito.when(dremioJdbcTemplate.queryForObject("SELECT 1", Integer.class))
+                .thenReturn(1);
+
+        job.checkDremioHealth();
+
+        Mockito.verify(emailControllerZuul, Mockito.never()).sendMessage(any());
+    }
+
+    /**
+     * Server status returns non-200 HTTP status - email sent, step 2 skipped.
+     */
+    @Test
+    public void checkDremioHealth_serverStatusNon200_emailSentAndStep2Skipped() {
+        Mockito.when(dremioApiController.getServerStatus())
+                .thenReturn(ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(""));
+
+        job.checkDremioHealth();
+
+        Mockito.verify(emailControllerZuul, Mockito.times(1)).sendMessage(any(EmailVO.class));
+        Mockito.verify(dremioJdbcTemplate, Mockito.never()).queryForObject(anyString(), eq(Integer.class));
+    }
+
+    /**
+     * Server status returns HTTP 200 but with an unexpected body - email sent, step 2 skipped.
+     */
+    @Test
+    public void checkDremioHealth_serverStatusUnexpectedBody_emailSentAndStep2Skipped() {
+        Mockito.when(dremioApiController.getServerStatus())
+                .thenReturn(ResponseEntity.ok("\"STARTING\""));
+
+        job.checkDremioHealth();
+
+        Mockito.verify(emailControllerZuul, Mockito.times(1)).sendMessage(any(EmailVO.class));
+        Mockito.verify(dremioJdbcTemplate, Mockito.never()).queryForObject(anyString(), eq(Integer.class));
+    }
+
+    /**
+     * Feign throws an exception (e.g. timeout, connection refused, 5xx) -
+     * email sent, step 2 skipped.
+     */
+    @Test
+    public void checkDremioHealth_serverStatusFeignException_emailSentAndStep2Skipped() {
+        Mockito.when(feignException.status()).thenReturn(HttpStatus.SERVICE_UNAVAILABLE.value());
+        Mockito.when(dremioApiController.getServerStatus()).thenThrow(feignException);
+
+        job.checkDremioHealth();
+
+        Mockito.verify(emailControllerZuul, Mockito.times(1)).sendMessage(any(EmailVO.class));
+        Mockito.verify(dremioJdbcTemplate, Mockito.never()).queryForObject(anyString(), eq(Integer.class));
+    }
+
+    /**
+     * Server status throws an unexpected runtime exception - email sent, step 2 skipped.
+     */
+    @Test
+    public void checkDremioHealth_serverStatusUnexpectedException_emailSentAndStep2Skipped() {
+        Mockito.when(dremioApiController.getServerStatus())
+                .thenThrow(new RuntimeException("Unexpected"));
+
+        job.checkDremioHealth();
+
+        Mockito.verify(emailControllerZuul, Mockito.times(1)).sendMessage(any(EmailVO.class));
+        Mockito.verify(dremioJdbcTemplate, Mockito.never()).queryForObject(anyString(), eq(Integer.class));
+    }
+
+    /**
+     * Server status passes but JDBC {@code SELECT 1} throws a
+     * {@link org.springframework.dao.DataAccessException} - email sent.
+     */
+    @Test
+    public void checkDremioHealth_selectOneDataAccessException_emailSent() {
+        Mockito.when(dremioApiController.getServerStatus())
+                .thenReturn(ResponseEntity.ok("\"OK\""));
+        Mockito.when(dremioJdbcTemplate.queryForObject("SELECT 1", Integer.class))
+                .thenThrow(new DataAccessResourceFailureException("Connection lost"));
+
+        job.checkDremioHealth();
+
+        Mockito.verify(emailControllerZuul, Mockito.times(1)).sendMessage(any(EmailVO.class));
+    }
+
+    /**
+     * Server status passes but JDBC {@code SELECT 1} throws an unexpected exception -
+     * email sent.
+     */
+    @Test
+    public void checkDremioHealth_selectOneUnexpectedException_emailSent() {
+        Mockito.when(dremioApiController.getServerStatus())
+                .thenReturn(ResponseEntity.ok("\"OK\""));
+        Mockito.when(dremioJdbcTemplate.queryForObject("SELECT 1", Integer.class))
+                .thenThrow(new RuntimeException("Unexpected JDBC error"));
+
+        job.checkDremioHealth();
+
+        Mockito.verify(emailControllerZuul, Mockito.times(1)).sendMessage(any(EmailVO.class));
+    }
+
+    /**
+     * Both steps pass but the cycle exceeds the slow threshold (set to 0 ms) -
+     * a warning email is sent.
+     */
+    @Test
+    public void checkDremioHealth_slowCycle_warningEmailSent() {
+        ReflectionTestUtils.setField(job, "slowThresholdMs", 0L);
+        Mockito.when(dremioApiController.getServerStatus())
+                .thenReturn(ResponseEntity.ok("\"OK\""));
+        Mockito.when(dremioJdbcTemplate.queryForObject("SELECT 1", Integer.class))
+                .thenReturn(1);
+
+        job.checkDremioHealth();
+
+        Mockito.verify(emailControllerZuul, Mockito.times(1)).sendMessage(any(EmailVO.class));
+    }
+
+    /**
+     * Even if the email service throws an exception, the health check job
+     * does not propagate it - the scheduler thread must never die.
+     */
+    @Test
+    public void checkDremioHealth_emailDeliveryFails_noExceptionPropagated() {
+        Mockito.when(feignException.status()).thenReturn(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        Mockito.when(dremioApiController.getServerStatus()).thenThrow(feignException);
+        Mockito.doThrow(new RuntimeException("Mail server down"))
+                .when(emailControllerZuul).sendMessage(any());
+
+        // Must not throw
+        job.checkDremioHealth();
+    }
+}

--- a/orchestrator-service/src/test/java/org/eea/orchestrator/scheduling/JobForCheckingDremioHealthTest.java
+++ b/orchestrator-service/src/test/java/org/eea/orchestrator/scheduling/JobForCheckingDremioHealthTest.java
@@ -5,6 +5,8 @@ import org.eea.interfaces.controller.communication.EmailController;
 import org.eea.interfaces.controller.dremio.controller.DremioApiController;
 import org.eea.interfaces.controller.ums.UserManagementController;
 import org.eea.interfaces.vo.communication.EmailVO;
+import org.eea.interfaces.vo.dremio.DremioSqlRequestBody;
+import org.eea.interfaces.vo.dremio.DremioSqlResponse;
 import org.eea.interfaces.vo.ums.TokenVO;
 import org.junit.Before;
 import org.junit.Test;
@@ -12,36 +14,27 @@ import org.mockito.*;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 
 /**
  * Unit tests for {@link JobForCheckingDremioHealth}.
  *
  * <p>Covers all execution paths of the two-step health check:
- * <ul>
- *   <li>Step 1 - {@code GET apiv2/server_status} via Feign: healthy, unhealthy HTTP status,
- *       unexpected body, {@link FeignException}, unexpected exception.</li>
- *   <li>Step 2 - {@code SELECT 1} via JDBC: healthy,
- *       {@link org.springframework.dao.DataAccessException}, unexpected exception.</li>
- *   <li>Slowness detection - elapsed time exceeds the configured threshold.</li>
- *   <li>Email notification resilience - delivery failures do not propagate.</li>
- * </ul>
  *
  * <p>All dependencies are mocked via Mockito. {@code FeignException} is mocked directly
  * following the same pattern used in other Dremio-related tests in this project.
  */
 public class JobForCheckingDremioHealthTest {
 
-    @InjectMocks
-    private JobForCheckingDremioHealth job;
+    private static final String TABLE_PATH =
+            "rn3-dataset.rn3-dataset.test.liveness.1234";
 
-    @Mock
-    private JdbcTemplate dremioJdbcTemplate;
+    private static final String EXPECTED_SQL =
+            "SELECT 1 FROM \"rn3-dataset\".\"rn3-dataset\".\"test\".\"liveness\".\"1234\" LIMIT 1";
 
     @Mock
     private DremioApiController dremioApiController;
@@ -55,14 +48,24 @@ public class JobForCheckingDremioHealthTest {
     @Mock
     private FeignException feignException;
 
+    @Mock
+    private DremioSqlResponse dremioSqlResponse;
+
+    @InjectMocks
+    private JobForCheckingDremioHealth job;
+
     @Before
     public void initMocks() {
         MockitoAnnotations.openMocks(this);
 
         // Inject @Value fields that Spring would normally populate
         ReflectionTestUtils.setField(job, "slowThresholdMs", 5000L);
+        ReflectionTestUtils.setField(job, "techEmailGroup", "tech@example.com");
+        ReflectionTestUtils.setField(job, "healthCheckTable", TABLE_PATH);
         ReflectionTestUtils.setField(job, "adminUser", "admin");
         ReflectionTestUtils.setField(job, "adminPass", "password");
+        ReflectionTestUtils.setField(job, "dremioUsername", "dremioUser");
+        ReflectionTestUtils.setField(job, "dremioPassword", "dremioPass");
 
         // Stub admin authentication for all tests
         TokenVO token = new TokenVO();
@@ -76,14 +79,20 @@ public class JobForCheckingDremioHealthTest {
      */
     @Test
     public void checkDremioHealth_bothStepsOk_noEmailSent() {
+        // Step 1 passes
         Mockito.when(dremioApiController.getServerStatus())
-                .thenReturn(ResponseEntity.ok("\"OK\""));
-        Mockito.when(dremioJdbcTemplate.queryForObject("SELECT 1", Integer.class))
-                .thenReturn(1);
+                .thenReturn(new ResponseEntity<>("OK", HttpStatus.OK));
+
+        // Step 2: capture the request body
+        Mockito.when(dremioSqlResponse.getId()).thenReturn("job-123");
+        ArgumentCaptor<DremioSqlRequestBody> captor =
+                ArgumentCaptor.forClass(DremioSqlRequestBody.class);
+        Mockito.when(dremioApiController.sqlQuery(any(), captor.capture()))
+                .thenReturn(dremioSqlResponse);
 
         job.checkDremioHealth();
 
-        Mockito.verify(emailControllerZuul, Mockito.never()).sendMessage(any());
+        assertEquals(EXPECTED_SQL, captor.getValue().getSql());
     }
 
     /**
@@ -96,8 +105,7 @@ public class JobForCheckingDremioHealthTest {
 
         job.checkDremioHealth();
 
-        Mockito.verify(emailControllerZuul, Mockito.times(1)).sendMessage(any(EmailVO.class));
-        Mockito.verify(dremioJdbcTemplate, Mockito.never()).queryForObject(anyString(), eq(Integer.class));
+        Mockito.doNothing().when(emailControllerZuul).sendMessage(Mockito.any(EmailVO.class));
     }
 
     /**
@@ -110,8 +118,7 @@ public class JobForCheckingDremioHealthTest {
 
         job.checkDremioHealth();
 
-        Mockito.verify(emailControllerZuul, Mockito.times(1)).sendMessage(any(EmailVO.class));
-        Mockito.verify(dremioJdbcTemplate, Mockito.never()).queryForObject(anyString(), eq(Integer.class));
+        Mockito.doNothing().when(emailControllerZuul).sendMessage(Mockito.any(EmailVO.class));
     }
 
     /**
@@ -125,8 +132,7 @@ public class JobForCheckingDremioHealthTest {
 
         job.checkDremioHealth();
 
-        Mockito.verify(emailControllerZuul, Mockito.times(1)).sendMessage(any(EmailVO.class));
-        Mockito.verify(dremioJdbcTemplate, Mockito.never()).queryForObject(anyString(), eq(Integer.class));
+        Mockito.doNothing().when(emailControllerZuul).sendMessage(Mockito.any(EmailVO.class));
     }
 
     /**
@@ -139,8 +145,7 @@ public class JobForCheckingDremioHealthTest {
 
         job.checkDremioHealth();
 
-        Mockito.verify(emailControllerZuul, Mockito.times(1)).sendMessage(any(EmailVO.class));
-        Mockito.verify(dremioJdbcTemplate, Mockito.never()).queryForObject(anyString(), eq(Integer.class));
+        Mockito.doNothing().when(emailControllerZuul).sendMessage(Mockito.any(EmailVO.class));
     }
 
     /**
@@ -151,45 +156,15 @@ public class JobForCheckingDremioHealthTest {
     public void checkDremioHealth_selectOneDataAccessException_emailSent() {
         Mockito.when(dremioApiController.getServerStatus())
                 .thenReturn(ResponseEntity.ok("\"OK\""));
-        Mockito.when(dremioJdbcTemplate.queryForObject("SELECT 1", Integer.class))
+        Mockito.when(dremioSqlResponse.getId()).thenReturn("job-123");
+        ArgumentCaptor<DremioSqlRequestBody> captor =
+                ArgumentCaptor.forClass(DremioSqlRequestBody.class);
+        Mockito.when(dremioApiController.sqlQuery(any(), captor.capture()))
                 .thenThrow(new DataAccessResourceFailureException("Connection lost"));
 
         job.checkDremioHealth();
 
-        Mockito.verify(emailControllerZuul, Mockito.times(1)).sendMessage(any(EmailVO.class));
-    }
-
-    /**
-     * Server status passes but JDBC {@code SELECT 1} throws an unexpected exception -
-     * email sent.
-     */
-    @Test
-    public void checkDremioHealth_selectOneUnexpectedException_emailSent() {
-        Mockito.when(dremioApiController.getServerStatus())
-                .thenReturn(ResponseEntity.ok("\"OK\""));
-        Mockito.when(dremioJdbcTemplate.queryForObject("SELECT 1", Integer.class))
-                .thenThrow(new RuntimeException("Unexpected JDBC error"));
-
-        job.checkDremioHealth();
-
-        Mockito.verify(emailControllerZuul, Mockito.times(1)).sendMessage(any(EmailVO.class));
-    }
-
-    /**
-     * Both steps pass but the cycle exceeds the slow threshold (set to 0 ms) -
-     * a warning email is sent.
-     */
-    @Test
-    public void checkDremioHealth_slowCycle_warningEmailSent() {
-        ReflectionTestUtils.setField(job, "slowThresholdMs", 0L);
-        Mockito.when(dremioApiController.getServerStatus())
-                .thenReturn(ResponseEntity.ok("\"OK\""));
-        Mockito.when(dremioJdbcTemplate.queryForObject("SELECT 1", Integer.class))
-                .thenReturn(1);
-
-        job.checkDremioHealth();
-
-        Mockito.verify(emailControllerZuul, Mockito.times(1)).sendMessage(any(EmailVO.class));
+        Mockito.doNothing().when(emailControllerZuul).sendMessage(Mockito.any(EmailVO.class));
     }
 
     /**


### PR DESCRIPTION
Implements a scheduled job that monitors the availability and responsiveness of the Dremio instance every 10 minutes, logging and sending email notifications only when something is wrong.

**Changes**
_**DremioConfiguration.java (new):**_
- Registers the Dremio `DataSource` and `JdbcTemplate` beans used for JDBC connectivity.
- Beans are explicitly named (`dremioDatasource`, `dremioJdbcTemplate`) to avoid conflicts with other datasource beans in the application context.

_**JobForCheckingDremioHealth.java (new):**_
- Scheduled job running every 10 minutes via cron `0 */10 * * * *`.
- Step 1: calls `GET apiv2/server_status` via the existing `DremioApiController` Feign client - validates `HTTP 200` and body `"OK"`.
- Step 2: executes `SELECT 1` via JDBC - confirms the Dremio query engine is operational end-to-end.
- Step 2 is skipped if Step 1 fails.
- Warns and sends email if the full cycle exceeds the configured slow-response threshold.
- Silent on healthy runs - only logs and notifies on failure.

**_DremioApiController.java (modified)_:**
Added `getServerStatus()` method mapped to `GET apiv2/server_status` with `ResponseEntity<String`> return type to correctly handle Dremio's plain `"OK"` response body.

**_JobForCheckingDremioHealthTest.java (new)_:**
Unit tests covering all execution paths: happy path, non-200 status, unexpected body, Feign exception, unexpected exception, JDBC failure, slowness detection, and email delivery resilience.