### PR TITLE
Makes the big data automatic geometry field names mutable in qc sql sentences #302799

### DIFF
--- a/common-interfaces/src/main/java/org/eea/interfaces/controller/validation/RulesController.java
+++ b/common-interfaces/src/main/java/org/eea/interfaces/controller/validation/RulesController.java
@@ -465,4 +465,19 @@ public interface RulesController {
    */
   @GetMapping(value = "/historicDatasetRules")
   List<DatasetHistoricRuleVO> getRuleHistoricByDatasetId(@RequestParam("datasetId") long datasetId);
+
+  /**
+   * Updates the automatic geometry names in sql for Big Data.
+   *
+   * @param datasetSchemaId the dataset schema id
+   * @param datasetId the dataset id
+   * @param tableSchemaId the table schema id
+   * @param fieldSchemaId the field schema id
+   */
+  @PutMapping("/private/updateBigDataGeometryRulesSql")
+  void updateBigDataGeometryRulesSql(
+      @RequestParam("datasetSchemaId") String datasetSchemaId,
+      @RequestParam("datasetId") Long datasetId,
+      @RequestParam(value = "tableSchemaId", required = false) String tableSchemaId,
+      @RequestParam(value = "fieldSchemaId", required = false) String fieldSchemaId);
 }

--- a/dataset-service/src/main/java/org/eea/dataset/service/impl/DataschemaServiceImpl.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/impl/DataschemaServiceImpl.java
@@ -791,9 +791,10 @@ public class DataschemaServiceImpl implements DatasetSchemaService {
     boolean typeModified = false;
     try {
       // Retrieve the FieldSchema from MongoDB
-      Document fieldSchema =
-              schemasRepository.findFieldSchema(datasetSchemaId, fieldSchemaVO.getId());
+      Document fieldSchema = schemasRepository.findFieldSchema(datasetSchemaId, fieldSchemaVO.getId());
       if (fieldSchema != null) {
+        String oldFieldName = fieldSchema.getString("headerName");
+
         // First of all, we update the previous data in the catalog
         updatePreviousDataInCatalog(fieldSchema, datasetId, cloningOrImporting);
 
@@ -803,12 +804,22 @@ public class DataschemaServiceImpl implements DatasetSchemaService {
         // we find if one data is modified
         typeModified = modifySchemaInUpdate(fieldSchemaVO, typeModified, fieldSchema);
 
+        String newFieldName = fieldSchema.getString("headerName");
+        DataType newType = getDataTypeFromFieldSchemaDocument(fieldSchema);
+        // Compare the old and new names of the field that's about to change.
+        boolean fieldNameChanged = StringUtils.isNotBlank(fieldSchemaVO.getName()) && !StringUtils.equals(oldFieldName, newFieldName);
+
         // Save the modified FieldSchema in the MongoDB
-        UpdateResult updateResult =
-                schemasRepository.updateFieldSchema(datasetSchemaId, fieldSchema);
+        UpdateResult updateResult = schemasRepository.updateFieldSchema(datasetSchemaId, fieldSchema);
         if (updateResult.getMatchedCount() == 1) {
           if (updateResult.getModifiedCount() == 1 && typeModified) {
             return fieldSchemaVO.getType();
+          }
+
+          // Move to validation service to change the actual sql sentence.
+          if (fieldNameChanged && !typeModified && isGeometryDataType(newType) && isBigDataDataset(datasetId)) {
+            LOG.info("Requested Big Data geometry QC SQL update after field rename from {} to {} in datasetId: {}", oldFieldName, newFieldName, datasetId);
+            rulesControllerZuul.updateBigDataGeometryRulesSql(datasetSchemaId, datasetId, null, fieldSchemaVO.getId());
           }
           return null;
         }
@@ -3710,6 +3721,66 @@ public class DataschemaServiceImpl implements DatasetSchemaService {
   public boolean isReferenceSchema(String datasetSchemaId){
     DataSetSchemaVO schema = getDataSchemaById(datasetSchemaId);
     return schema != null && Boolean.TRUE.equals(schema.getReferenceDataset());
+  }
+
+  /**
+   * Gets the DataType from a raw Mongo field schema document.
+   *
+   * @param fieldSchema the field schema document
+   * @return the field DataType, or null if it cannot be resolved
+   */
+  private DataType getDataTypeFromFieldSchemaDocument(Document fieldSchema) {
+    if (fieldSchema == null) {
+      return null;
+    }
+
+    Object dataType = fieldSchema.get("typeData");
+
+    if (dataType instanceof DataType) {
+      return (DataType) dataType;
+    }
+
+    if (dataType instanceof String && StringUtils.isNotBlank((String) dataType)) {
+      try {
+        return DataType.valueOf((String) dataType);
+      } catch (IllegalArgumentException e) {
+        LOG.warn("Unknown DataType value found in field schema document: {}", dataType);
+        return null;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Checks whether a field type is one of the spatial geometry types.
+   *
+   * @param type the field data type
+   * @return true if the type is a geometry type
+   */
+  private boolean isGeometryDataType(DataType type) {
+    return DataType.POINT.equals(type)
+        || DataType.MULTIPOINT.equals(type)
+        || DataType.LINESTRING.equals(type)
+        || DataType.MULTILINESTRING.equals(type)
+        || DataType.POLYGON.equals(type)
+        || DataType.MULTIPOLYGON.equals(type)
+        || DataType.GEOMETRYCOLLECTION.equals(type);
+  }
+
+  /**
+   * Checks whether the dataset belongs to a Big Data dataflow.
+   *
+   * @param datasetId the dataset id
+   * @return true if the dataset belongs to a Big Data dataflow
+   */
+  private boolean isBigDataDataset(Long datasetId) {
+    if (datasetId == null) {
+      return false;
+    }
+
+    Long dataflowId = datasetService.getDataFlowIdById(datasetId);
+    return Boolean.TRUE.equals(dataFlowControllerZuul.isBigDataflow(dataflowId));
   }
 
 }

--- a/validation-service/src/main/java/org/eea/validation/controller/RulesControllerImpl.java
+++ b/validation-service/src/main/java/org/eea/validation/controller/RulesControllerImpl.java
@@ -1269,5 +1269,27 @@ public class RulesControllerImpl implements RulesController {
     }
   }
 
+  /**
+   * Updates the automatic geometry names in sql for Big Data.
+   *
+   * @param datasetSchemaId the dataset schema id
+   * @param datasetId the dataset id
+   * @param tableSchemaId the table schema id
+   * @param fieldSchemaId the field schema id
+   */
+  @Override
+  @HystrixCommand
+  @PutMapping("/private/updateBigDataGeometryRulesSql")
+  @ApiOperation(value = "Updates Big Data geometry automatic QC SQL rules after schema name changes", hidden = true)
+  public void updateBigDataGeometryRulesSql(String datasetSchemaId, Long datasetId,
+                                            String tableSchemaId, String fieldSchemaId) {
+    try {
+      rulesService.updateBigDataGeometryRulesSql(datasetSchemaId, datasetId, tableSchemaId, fieldSchemaId);
+    } catch (Exception e) {
+      LOG.error("Unexpected error updating Big Data geometry QC SQL rules. datasetSchemaId: {}, datasetId: {}, tableSchemaId: {}, fieldSchemaId: {}. Message: {}",
+          datasetSchemaId, datasetId, tableSchemaId, fieldSchemaId, e.getMessage(), e);
+      throw e;
+    }
+  }
 
 }

--- a/validation-service/src/main/java/org/eea/validation/service/RulesService.java
+++ b/validation-service/src/main/java/org/eea/validation/service/RulesService.java
@@ -364,4 +364,14 @@ public interface RulesService {
    * @return
    */
   RuleVO findRule(String datasetSchemaId, String ruleId);
+
+  /**
+   * Update Big Data geometry rules sql.
+   *
+   * @param datasetSchemaId
+   * @param datasetId
+   * @param tableSchemaId
+   * @param fieldSchemaId
+   */
+  void updateBigDataGeometryRulesSql(String datasetSchemaId, Long datasetId, String tableSchemaId, String fieldSchemaId);
 }

--- a/validation-service/src/main/java/org/eea/validation/service/impl/RulesServiceImpl.java
+++ b/validation-service/src/main/java/org/eea/validation/service/impl/RulesServiceImpl.java
@@ -2351,6 +2351,136 @@ public class RulesServiceImpl implements RulesService {
   public RuleVO findRule(String datasetSchemaId, String ruleId) {
     return ruleMapper.entityToClass(rulesRepository.findRule(new ObjectId(datasetSchemaId), new ObjectId(ruleId)));
   }
+
+  /**
+   * Update Big Data geometry rule sql sentence.
+   *
+   * @param datasetSchemaId
+   * @param datasetId
+   * @param tableSchemaId
+   * @param fieldSchemaId
+   */
+  @Override
+  public void updateBigDataGeometryRulesSql(String datasetSchemaId, Long datasetId, String tableSchemaId, String fieldSchemaId) {
+    if (StringUtils.isBlank(datasetSchemaId) || datasetId == null) {
+      LOG.warn("Skipping QC SQL update. DatasetSchemaId or datasetId empty or missing. datasetSchemaId={}, datasetId={}", datasetSchemaId, datasetId);
+      return;
+    }
+    ObjectId datasetSchemaObjectId = new ObjectId(datasetSchemaId);
+    DataSetSchema dataSetSchema = schemasRepository.findByIdDataSetSchema(datasetSchemaObjectId);
+
+    if (dataSetSchema == null || dataSetSchema.getTableSchemas() == null) {
+      LOG.warn("Skipping QC SQL update. DatasetSchema not found. datasetSchemaId={}", datasetSchemaId);
+      return;
+    }
+
+    RulesSchema rulesSchema = rulesRepository.findByIdDatasetSchema(datasetSchemaObjectId);
+
+    if (rulesSchema == null || rulesSchema.getRules() == null || rulesSchema.getRules().isEmpty()) {
+      LOG.warn("Skipping QC SQL update. Rules schema empty or missing. datasetSchemaId={}", datasetSchemaId);
+      return;
+    }
+
+    // Table ObjectId null if tableSchemaId doesn't exist.
+    ObjectId tableObjectId = StringUtils.isNotBlank(tableSchemaId) ? new ObjectId(tableSchemaId) : null;
+    // Field ObjectId null if fieldSchemaId doesn't exist.
+    ObjectId fieldObjectId = StringUtils.isNotBlank(fieldSchemaId) ? new ObjectId(fieldSchemaId) : null;
+
+    // Iterate through all dataset tables and table fields to find the geometry rule that we want to change it's sentence.
+    for (TableSchema tableSchema : dataSetSchema.getTableSchemas()) {
+      if (tableSchema == null || tableSchema.getRecordSchema() == null || tableSchema.getRecordSchema().getFieldSchema() == null) {
+        continue;
+      }
+
+      if (tableObjectId != null && !tableObjectId.equals(tableSchema.getIdTableSchema())) {
+        continue;
+      }
+
+      for (FieldSchema fieldSchema : tableSchema.getRecordSchema().getFieldSchema()) {
+        if (fieldSchema == null) {
+          continue;
+        }
+
+        if (fieldObjectId != null && !fieldObjectId.equals(fieldSchema.getIdFieldSchema())) {
+          continue;
+        }
+
+        if (!isGeometryDataType(fieldSchema.getType())) {
+          continue;
+        }
+
+        // Get the Rule with the given rule schema.
+        Rule geometrySqlRule = findGeometrySqlRule(rulesSchema, fieldSchema.getIdFieldSchema());
+
+        if (geometrySqlRule == null) {
+          LOG.warn("No rule was found with fieldSchemaId: {}", fieldSchema.getIdFieldSchema());
+          continue;
+        }
+
+        // Constract the new sql sentence with the new name.
+        String newSqlSentence = buildBigDataGeometrySqlSentence(datasetId, tableSchema.getNameTableSchema(), fieldSchema.getHeaderName());
+
+        // Continue if the old sentence is the same with the new one.
+        if (StringUtils.equals(geometrySqlRule.getSqlSentence(), newSqlSentence)) {
+          LOG.info("New SQL sentence is the same as the previous one for ruleId: {}, fieldName: {}", geometrySqlRule.getRuleId(), fieldSchema.getHeaderName());
+          continue;
+        }
+
+        // Set the new sql sentence and update the Rule.
+        LOG.info("Updating Big Data geometry QC SQL rule for fieldName: {} and ruleId:{}", fieldSchema.getHeaderName(), geometrySqlRule.getRuleId());
+        geometrySqlRule.setSqlSentence(newSqlSentence);
+        rulesRepository.updateRule(datasetSchemaObjectId, geometrySqlRule);
+      }
+    }
+    LOG.info("Finished Big Data geometry QC SQL update for datasetId={} and fieldSchemaId: {}", datasetId, fieldSchemaId);
+  }
+
+  /**
+   * Gets the Rule from the given rules and field schemas.
+   *
+   * @param rulesSchema the rule schema
+   * @param fieldSchemaId the field schema id
+   * @return the found Rule
+   */
+  private Rule findGeometrySqlRule(RulesSchema rulesSchema, ObjectId fieldSchemaId) {
+    return rulesSchema.getRules().stream()
+        .filter(rule -> fieldSchemaId.equals(rule.getReferenceId()))
+        .filter(Rule::isAutomatic)
+        .filter(rule -> AutomaticRuleTypeEnum.FIELD_SQL_TYPE.equals(rule.getAutomaticType()))
+        .filter(rule -> StringUtils.isNotBlank(rule.getSqlSentence()))
+        .findFirst()
+        .orElse(null);
+  }
+
+  /**
+   * Gets the Rule from the given rules and field schemas.
+   *
+   * @param datasetId the dataset id
+   * @param tableName the table name
+   * @param fieldName the field name
+   * @return the SQL sentence
+   */
+  private String buildBigDataGeometrySqlSentence(Long datasetId, String tableName, String fieldName) {
+    String fromClause = String.format(FROM_CLAUSE_STATEMENT, datasetId, tableName);
+    return String.format(SPATIAL_DATA_NEW_AUTOMATIC_QC_RULE_SENTENCE, fieldName, fromClause, fieldName, fieldName);
+  }
+
+  /**
+   * Checks if the given data is of geometry type.
+   *
+   * @param type the data type
+   * @return true, if geometry
+   */
+  private boolean isGeometryDataType(DataType type) {
+    return DataType.POINT.equals(type)
+        || DataType.MULTIPOINT.equals(type)
+        || DataType.LINESTRING.equals(type)
+        || DataType.MULTILINESTRING.equals(type)
+        || DataType.POLYGON.equals(type)
+        || DataType.MULTIPOLYGON.equals(type)
+        || DataType.GEOMETRYCOLLECTION.equals(type);
+  }
+
   /**
    * Update rule state.
    *

--- a/validation-service/src/main/java/org/eea/validation/service/impl/RulesServiceImpl.java
+++ b/validation-service/src/main/java/org/eea/validation/service/impl/RulesServiceImpl.java
@@ -2466,7 +2466,7 @@ public class RulesServiceImpl implements RulesService {
   }
 
   /**
-   * Checks if the given data is of geometry type.
+   * Checks whether a field type is one of the spatial geometry types.
    *
    * @param type the data type
    * @return true, if geometry


### PR DESCRIPTION
The geometry automatic QC rule sql sentences didn't update after the name change of a field for Big Data. That caused validations to hit NPEs and break due to missing/unknown fields.