### PR TITLE
Bug #302495 RN3 - the attachment field size limit is not shown in the…

### DIFF
--- a/dataset-service/src/main/java/org/eea/dataset/controller/DatasetSchemaControllerImpl.java
+++ b/dataset-service/src/main/java/org/eea/dataset/controller/DatasetSchemaControllerImpl.java
@@ -832,6 +832,8 @@ public class DatasetSchemaControllerImpl implements DatasetSchemaController {
           @ApiParam(value = "Field schema object") @RequestBody FieldSchemaVO fieldSchemaVO) {
 
 
+    final boolean isBigData = dataflowControllerZuul.isBigDataflowDataset(datasetId);
+
     if (null != fieldSchemaVO.getName()) {
       if (fieldSchemaVO.getName().chars().anyMatch(Character::isWhitespace)) {
         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, EEAErrorMessage.FIELD_NAME_WHITESPACES);
@@ -859,7 +861,7 @@ public class DatasetSchemaControllerImpl implements DatasetSchemaController {
         dataschemaService.updateForeignRelation(datasetId, fieldSchemaVO, datasetSchema);
 
         // Clear the attachments if necessary
-        if (Boolean.TRUE.equals(
+        if (!isBigData && Boolean.TRUE.equals(
                 dataschemaService.checkClearAttachments(datasetId, datasetSchema, fieldSchemaVO))) {
           datasetService.deleteAttachmentByFieldSchemaId(datasetId, fieldSchemaVO.getId());
         }

--- a/dataset-service/src/test/java/org/eea/dataset/controller/DatasetSchemaControllerImplTest.java
+++ b/dataset-service/src/test/java/org/eea/dataset/controller/DatasetSchemaControllerImplTest.java
@@ -1168,6 +1168,7 @@ public class DatasetSchemaControllerImplTest {
 
     DataFlowVO dataflowVO = new DataFlowVO();
     dataflowVO.setStatus(TypeStatusEnum.DESIGN);
+    Mockito.when(dataflowControllerZuul.isBigDataflowDataset(1L)).thenReturn(false);
     Mockito.when(dataflowControllerZuul.getMetabaseById(Mockito.anyLong())).thenReturn(dataflowVO);
     Mockito.when(datasetService.getDataFlowIdById(Mockito.anyLong())).thenReturn(1L);
 


### PR DESCRIPTION
… dataset schema

- removed call to  datasetService.deleteAttachmentByFieldSchemaId() for BigData dataflows