### PR TITLE
Stream attachment exports for public files from List to reduce memory usage #305064

### DIFF
--- a/dataset-service/src/main/java/org/eea/dataset/persistence/data/repository/AttachmentRepository.java
+++ b/dataset-service/src/main/java/org/eea/dataset/persistence/data/repository/AttachmentRepository.java
@@ -1,10 +1,15 @@
 package org.eea.dataset.persistence.data.repository;
 
 import java.util.List;
+import java.util.stream.Stream;
+
 import org.eea.dataset.persistence.data.domain.AttachmentValue;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
+
+import javax.persistence.QueryHint;
 
 
 /**
@@ -50,4 +55,20 @@ public interface AttachmentRepository extends PagingAndSortingRepository<Attachm
       @Param("idFieldSchemas") String idFieldSchemas);
 
 
+  /**
+   * Find all by id field schema and value is not null and add them in a Stream.
+   *
+   * @param idFieldSchemas the id field schemas
+   * @return the list
+   */
+  @QueryHints(value = {
+      // Enforces JDBC cursor fetch size so Postgres streams records.
+      @QueryHint(name = org.hibernate.annotations.QueryHints.FETCH_SIZE, value = "10"),
+      // Tells Hibernate not to keep dirty-checking snapshots of files in memory.
+      @QueryHint(name = org.hibernate.annotations.QueryHints.READ_ONLY, value = "true")
+  })
+  @Query("SELECT attv FROM FieldValue fv, AttachmentValue attv WHERE fv.idFieldSchema = :idFieldSchemas "
+      + "AND fv.value is not null AND fv.id = attv.fieldValue")
+  Stream<AttachmentValue> streamAllByIdFieldSchemaAndValueIsNotNull(
+      @Param("idFieldSchemas") String idFieldSchemas);
 }

--- a/dataset-service/src/main/java/org/eea/dataset/service/DatasetService.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/DatasetService.java
@@ -34,6 +34,7 @@ import java.io.OutputStream;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.ZipOutputStream;
 
 /**
  * The interface Dataset service.
@@ -753,4 +754,19 @@ public interface DatasetService {
           String recordId,
           String fieldId
   ) throws EEAException;
+
+  /**
+   * Streams attachments for the given field schema and writes them to the ZIP output stream. We were originally constracting
+   * a List instead of a Stream and it caused java heap exception that was discovered in ticket #305064. The process was moved
+   * in the service to be transactional with readOnly without changing the callers that managed insert and delete actions.
+   *
+   * @param datasetId The dataset id
+   * @param fieldSchemaId The field schema id
+   * @param tableSchemaId The table schema id
+   * @param tableName The table name
+   * @param out the ZIP output stream
+   * @throws IOException if an attachment cannot be written
+   */
+  void writeAttachmentsToZip(@DatasetId Long datasetId, String fieldSchemaId, String tableSchemaId, String tableName, ZipOutputStream out) throws IOException;
+
 }

--- a/dataset-service/src/main/java/org/eea/dataset/service/helper/FileTreatmentHelper.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/helper/FileTreatmentHelper.java
@@ -131,6 +131,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -3405,83 +3406,58 @@ public class FileTreatmentHelper implements DisposableBean {
         }
     }
 
-        private void createFilesAndZip (Long dataflowId, Long dataProviderId,
-                DataSetMetabase datasetToFile,byte[] file, String nameFileUnique, String nameFileScape)
-      throws IOException {
+    private void createFilesAndZip(Long dataflowId, Long dataProviderId, DataSetMetabase datasetToFile,
+                                   byte[] file, String nameFileUnique, String nameFileScape) throws IOException {
+        // we create folder to save the file.zip
+        File fileFolderProvider;
+        if (dataProviderId != null) {
+            fileFolderProvider = new File((new File(pathPublicFile, "dataflow-" + dataflowId.toString())),
+                "dataProvider-" + dataProviderId.toString());
+        } else {
+            fileFolderProvider = new File(pathPublicFile, "dataflow-" + dataflowId.toString());
+        }
+        fileFolderProvider.mkdirs();
 
-            // we create folder to save the file.zip
-            File fileFolderProvider = null;
-            if (dataProviderId != null) {
-                fileFolderProvider = new File((new File(pathPublicFile, "dataflow-" + dataflowId.toString())),
-                        "dataProvider-" + dataProviderId.toString());
-            } else {
-                fileFolderProvider = new File(pathPublicFile, "dataflow-" + dataflowId.toString());
-            }
-            fileFolderProvider.mkdirs();
+        // we create the file.zip
+        File fileWriteZip = new File(fileFolderProvider, nameFileUnique + ".zip");
 
-            // we create the file.zip
-            File fileWriteZip = null;
-            if (dataProviderId != null) {
-                fileWriteZip =
-                        new File(new File(new File(pathPublicFile, "dataflow-" + dataflowId.toString()),
-                                "dataProvider-" + dataProviderId.toString()), nameFileUnique + ".zip");
-            } else {
-                fileWriteZip = new File(new File(pathPublicFile, "dataflow-" + dataflowId.toString()),
-                        nameFileUnique + ".zip");
-            }
-            // create the context to add all files in a treemap inside to attachment and file information
-            try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(fileWriteZip.toString()))) {
-                // we get the dataschema and check every table to see if find any field attachemnt
-                DataSetSchema dataSetSchema =
-                        schemasRepository.findByIdDataSetSchema(new ObjectId(datasetToFile.getDatasetSchema()));
-                for (TableSchema tableSchema : dataSetSchema.getTableSchemas()) {
+        // create the context to add all files in a treemap inside to attachment and file information
+        try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(fileWriteZip.toString()))) {
+            // we get the dataschema and check every table to see if find any field attachemnt
+            DataSetSchema dataSetSchema =
+                schemasRepository.findByIdDataSetSchema(new ObjectId(datasetToFile.getDatasetSchema()));
+            for (TableSchema tableSchema : dataSetSchema.getTableSchemas()) {
 
-                    // we find if in any table have one field type ATTACHMENT
-                    List<FieldSchema> fieldSchemaAttachment = tableSchema.getRecordSchema().getFieldSchema()
-                            .stream().filter(field -> DataType.ATTACHMENT.equals(field.getType()))
-                            .collect(Collectors.toList());
-                    if (!CollectionUtils.isEmpty(fieldSchemaAttachment)) {
-
-                        LOG.info("We  are in tableSchema with id {} looking if we have attachments",
-                                tableSchema.getIdTableSchema());
-                        // We took every field for every table
-                        for (FieldSchema fieldAttach : fieldSchemaAttachment) {
-                            List<AttachmentValue> attachmentValue = attachmentRepository
-                                    .findAllByIdFieldSchemaAndValueIsNotNull(fieldAttach.getIdFieldSchema().toString());
-
-                            // if there are filled we create a folder and inside of any folder we create the fields
-                            if (!CollectionUtils.isEmpty(attachmentValue)) {
-                                LOG.info(
-                                        "We  are in tableSchema with id {}, checking field {} and we have attachments files",
-                                        tableSchema.getIdTableSchema(), fieldAttach.getIdFieldSchema());
-
-                                for (AttachmentValue attachment : attachmentValue) {
-                                    try {
-                                        ZipEntry eFieldAttach = new ZipEntry(
-                                                tableSchema.getNameTableSchema() + "/" + attachment.getFileName());
-                                        out.putNextEntry(eFieldAttach);
-                                        out.write(attachment.getContent(), 0, attachment.getContent().length);
-                                    } catch (ZipException e) {
-                                        LOG.info("Error creating file {} because already exist", attachment.getFileName(),
-                                                e);
-                                    }
-                                    out.closeEntry();
-                                }
-                            }
-                        }
-                    }
+                // we find if in any table have one field type ATTACHMENT
+                List<FieldSchema> fieldSchemaAttachment = tableSchema.getRecordSchema().getFieldSchema()
+                    .stream().filter(field -> DataType.ATTACHMENT.equals(field.getType()))
+                    .collect(Collectors.toList());
+                if (CollectionUtils.isEmpty(fieldSchemaAttachment)) {
+                    continue;
                 }
 
-                ZipEntry e = new ZipEntry(nameFileScape);
-                out.putNextEntry(e);
-                out.write(file, 0, file.length);
-                out.closeEntry();
-                LOG.info("We create file {} in the route ", fileWriteZip);
-            } catch (Exception e) {
-                LOG.error("Unexpected error! Error in createFilesAndZip for dataflowId {} and dataProviderId {}. Message: {}", dataflowId, dataProviderId, e.getMessage());
-                throw e;
+                LOG.info("We  are in tableSchema with id {} looking if we have attachments", tableSchema.getIdTableSchema());
+                // We took every field for every table
+                for (FieldSchema fieldAttach : fieldSchemaAttachment) {
+                    datasetService.writeAttachmentsToZip(
+                        datasetToFile.getId(),
+                        fieldAttach.getIdFieldSchema().toString(),
+                        tableSchema.getIdTableSchema().toString(),
+                        tableSchema.getNameTableSchema(),
+                        out);
+                }
             }
+
+            ZipEntry e = new ZipEntry(nameFileScape);
+            out.putNextEntry(e);
+            out.write(file, 0, file.length);
+            out.closeEntry();
+            LOG.info("We create file {} in the route ", fileWriteZip);
+        } catch (Exception e) {
+            LOG.error("Unexpected error! Error in createFilesAndZip for dataflowId {} and dataProviderId {}. Message: {}", dataflowId, dataProviderId, e.getMessage());
+            throw e;
         }
+    }
 
     private void createFilesAndZipDL(DataSetMetabase dataset, String zipDestinationPath, String nameFileUnique) throws EEAException {
         try {

--- a/dataset-service/src/main/java/org/eea/dataset/service/impl/DatasetServiceImpl.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/impl/DatasetServiceImpl.java
@@ -87,6 +87,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import javax.transaction.Transactional;
 import java.io.*;
 import java.lang.reflect.InvocationTargetException;
@@ -94,7 +96,12 @@ import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
+import java.util.zip.ZipOutputStream;
 
 import static org.eea.utils.LiteralConstants.*;
 
@@ -334,6 +341,9 @@ public class DatasetServiceImpl implements DatasetService {
   /** The import path. */
   @Value("${importPath}")
   private String importPath;
+
+  @PersistenceContext
+  private EntityManager entityManager;
 
   /**
    * The default process priority
@@ -3980,4 +3990,70 @@ public class DatasetServiceImpl implements DatasetService {
     // 3. Return as bytes
     return geoJson.getBytes(StandardCharsets.UTF_8);
   }
+
+  /**
+   * Streams attachments for the given field schema and writes them to the ZIP output stream. We were originally constracting
+   * a List instead of a Stream and it caused java heap exception that was discovered in ticket #305064. The process was moved
+   * in the service to be transactional with readOnly without changing the callers that managed insert and delete actions.
+   *
+   * @param datasetId The dataset id
+   * @param fieldSchemaId The field schema id
+   * @param tableSchemaId The table schema id
+   * @param tableName The table name
+   * @param out the ZIP output stream
+   * @throws IOException if an attachment cannot be written
+   */
+  @Override
+  @org.springframework.transaction.annotation.Transactional(readOnly = true)
+  public void writeAttachmentsToZip(@DatasetId Long datasetId, String fieldSchemaId, String tableSchemaId, String tableName, ZipOutputStream out) throws IOException {
+    try (Stream<AttachmentValue> attachments =
+             attachmentRepository
+                 .streamAllByIdFieldSchemaAndValueIsNotNull(fieldSchemaId)) {
+
+      try {
+        attachments.forEachOrdered(attachment -> {
+          boolean zipOutputStreamOpened = false;
+
+          try {
+            LOG.info("We are in tableSchema with id {}, checking field {} and processing attachment {}",
+                tableSchemaId, fieldSchemaId, attachment.getFileName());
+
+            ZipEntry attachmentEntry = new ZipEntry(tableName + "/" + attachment.getFileName());
+
+            out.putNextEntry(attachmentEntry);
+            zipOutputStreamOpened = true;
+
+            // Stream bytes directly to the zip file.
+            byte[] content = attachment.getContent();
+            if (content != null) {
+              out.write(content, 0, content.length);
+            }
+
+          } catch (ZipException e) {
+            LOG.info("Error creating file {} because it already exists", attachment.getFileName(), e);
+          } catch (IOException e) {
+            throw new UncheckedIOException(e);
+          } finally {
+            if (zipOutputStreamOpened) {
+              try {
+                out.closeEntry();
+              } catch (IOException e) {
+                throw new UncheckedIOException(e);
+              }
+            }
+
+            if (entityManager.contains(attachment)) {
+              // CRITICAL FOR MEMORY: Detach from the persistence context.
+              // This breaks the Hibernate reference, allowing GC to free up memory immediately.
+              entityManager.detach(attachment);
+            }
+          }
+        });
+
+      } catch (UncheckedIOException e) {
+        throw e.getCause();
+      }
+    }
+  }
+
 }

--- a/dataset-service/src/test/java/org/eea/dataset/service/helper/FileTreatmentHelperTest.java
+++ b/dataset-service/src/test/java/org/eea/dataset/service/helper/FileTreatmentHelperTest.java
@@ -1147,8 +1147,6 @@ public class FileTreatmentHelperTest {
     when(contextExport.fileWriter(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
         Mockito.anyBoolean(), Mockito.any())).thenReturn(expectedResult);
     attachment.setContent(expectedResult);
-    when(attachmentRepository.findAllByIdFieldSchemaAndValueIsNotNull(Mockito.anyString()))
-        .thenReturn(Arrays.asList(attachment));
 
 
     fileTreatmentHelper.createReferenceDatasetFiles(dataset);


### PR DESCRIPTION
This change updates public files .zip generation to **Stream** attachment records instead of loading all attachment contents into memory at once in a list. Attachments are processed inside a read-only transaction with a configured fetch size and detached after writing, reducing heap usage and preventing **OutOfMemoryError** during public file creation.