### PR TITLE
#304900 receipt text editor not multiline

### DIFF
--- a/dataset-service/src/main/java/org/eea/dataset/service/pdf/ReceiptPDFGenerator.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/pdf/ReceiptPDFGenerator.java
@@ -8,6 +8,8 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.apache.pdfbox.contentstream.PDContentStream;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
@@ -364,12 +366,19 @@ public class ReceiptPDFGenerator {
    * @return an array of lines
    */
   private String[] splitInDifferentLinesByLineCharacterLength(String input, int maxLineLength) {
-    // Split the input text into words
-    String[] words = input.split(" ");
+    // Split the input text into words by spaces and \n characters. Keep the \n characters as words.
+    String[] words = input.split(" |(?<=\\n)|(?=\\n)");
+
     StringBuilder currentLine = new StringBuilder();
     List<String> lines = new ArrayList<>();
 
     for (String word : words) {
+
+      if (word.equals("\n")) {
+        lines.add(currentLine.toString());
+        currentLine.setLength(0); // Reset the StringBu
+        continue;
+      }
       // If the current line plus this word exceeds the max length, add the current line to the list and start a new one
       if (currentLine.length() + word.length() + 1 > maxLineLength) {
         lines.add(currentLine.toString());
@@ -389,4 +398,5 @@ public class ReceiptPDFGenerator {
 
     return lines.toArray(new String[0]);
   }
+
 }

--- a/frontend-service/src/views/_components/ManageDataflow/ManageDataflow.jsx
+++ b/frontend-service/src/views/_components/ManageDataflow/ManageDataflow.jsx
@@ -456,7 +456,7 @@ export const ManageDataflow = ({
               <h4 className={styles.addUserTextLabel}>{resourcesContext.messages['addUserTextToReceiptEdit']}</h4>
               <InputTextarea
                 className={`class`}
-                collapsedHeight={75}
+                collapsedHeight={150}
                 hasMaxCharCounter={true}
                 id="createDataCollectionText"
                 key="createDataCollectionText"
@@ -466,7 +466,6 @@ export const ManageDataflow = ({
                 onFocus={e => {
                   setAddInitialUserText(e.target.value);
                 }}
-                onKeyDown={e => onKeyChange(e)}
                 placeholder={resourcesContext.messages['addUserTextToReceiptNew']}
                 value={addUserText}
               />


### PR DESCRIPTION
[(https://taskman.eionet.europa.eu/issues/304900)](url)

Front end:
When in edit dataflow dialog in a dataflow with technical acceptance step enabled as a custodian, the user wants to be able to enter new lines in the editText on receipt box and the box to appear bigger.
<img width="1213" height="1067" alt="image" src="https://github.com/user-attachments/assets/a1eaa2ba-d319-4b4a-990b-de69ada55d0b" />


Backend 
When the user wants to get the receipt, the new lines must be printed on the receipt as well.