### PR TITLE
Bug #304930 RN3: Confirmation receipt format issue

### DIFF
--- a/dataset-service/src/main/java/org/eea/dataset/service/pdf/ReceiptPDFGenerator.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/pdf/ReceiptPDFGenerator.java
@@ -56,6 +56,12 @@ public class ReceiptPDFGenerator {
   /** A rectangle the size of A5 Paper. */
   public static final PDRectangle A4 = new PDRectangle(210 * POINTS_PER_MM, 297 * POINTS_PER_MM);
 
+  private PDDocument document;
+
+  private PDPage page;
+
+  private PDPageContentStream contentStream;
+
   /**
    * Generate PDF.
    *
@@ -64,12 +70,14 @@ public class ReceiptPDFGenerator {
    */
   public void generatePDF(ReleaseReceiptInfoVO receipt, OutputStream out, Boolean isManualAcceptance) {
     if (out != null) {
-      try (PDDocument document = new PDDocument()) {
+      try (PDDocument pddocument = new PDDocument()) {
+
+        document = pddocument;
         // Create and add an A4 page
-        PDPage page = new PDPage(A4);
+        page = new PDPage(A4);
         document.addPage(page);
 
-        printContentPDF(receipt, document, page, isManualAcceptance);
+        printContentPDF(receipt, isManualAcceptance);
 
         // Save and close the PDF
         document.save(out);
@@ -89,11 +97,9 @@ public class ReceiptPDFGenerator {
    * Prints the content PDF.
    *
    * @param receipt the receipt
-   * @param document the document
-   * @param page the page
    * @throws IOException Signals that an I/O exception has occurred.
    */
-  private void printContentPDF(ReleaseReceiptInfoVO receipt, PDDocument document, PDPage page, Boolean isManualAcceptance)
+  private void printContentPDF(ReleaseReceiptInfoVO receipt, Boolean isManualAcceptance)
       throws IOException {
 
     float x;
@@ -104,7 +110,7 @@ public class ReceiptPDFGenerator {
     ZoneId timeZone = ZoneId.of(LiteralConstants.EUROPE_ZONE_ID);
     DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-    PDPageContentStream contentStream = new PDPageContentStream(document, page);
+    contentStream = new PDPageContentStream(document, page);
     PDType0Font font;
     PDType0Font fontBold;
     PDImageXObject pdImage;
@@ -173,6 +179,7 @@ public class ReceiptPDFGenerator {
         fontSize)) {
       printLinePDF(contentStream, line, fontBold, fontSize, x, y);
       y -= spaceBetweenLines + fontSize;
+      y = checkForPageChange(y);
     }
 
     // Print dataflow link
@@ -181,11 +188,13 @@ public class ReceiptPDFGenerator {
     String dataflowLink = reportneturl + "/dataflow/" + receipt.getIdDataflow();
     printLinePDF(contentStream, dataflowLink, font, fontSize, 133f, y);
     y -= spaceBetweenLines + fontSize;
+    y = checkForPageChange(y);
 
     fontSize = 58f;
 
     // Print obligation information
     y -= 18f;
+    y = checkForPageChange(y);
     text = "Obligation: ";
     printLinePDF(contentStream, text, fontBold, fontSize, x, y);
     x += fontBold.getStringWidth(text) / 1000 * fontSize;
@@ -193,6 +202,7 @@ public class ReceiptPDFGenerator {
         fontSize)) {
       printLinePDF(contentStream, line, font, fontSize, x, y);
       y -= spaceBetweenLines + fontSize;
+      y = checkForPageChange(y);
     }
     text = "https://rod.eionet.europa.eu/obligations/" + receipt.getObligationId();
     printLinePDF(contentStream, text, font, fontSize, x, y);
@@ -200,6 +210,7 @@ public class ReceiptPDFGenerator {
 // Print Additional notes text if the dataflow has Manual Acceptance step
     if (Boolean.TRUE.equals(isManualAcceptance)) {
       y -= spaceBetweenLines * 2 + fontSize;
+      y = checkForPageChange(y);
 
       String[] lines;
       if (receipt.getNote() != null && !receipt.getNote().isEmpty()) {
@@ -217,16 +228,19 @@ public class ReceiptPDFGenerator {
       for (String line : lines) {
         printLinePDF(contentStream, line, font, fontSize, 133f, y);
         y -= spaceBetweenLines + fontSize; // Move down for the next line
+        y = checkForPageChange(y);
       }
     }
 
     // Print dataset list
     y -= spaceBetweenLines * 2 + fontSize;
+    y = checkForPageChange(y);
     printLinePDF(contentStream, "Datasets", fontBold, fontSize, 133f, y);
     printLinePDF(contentStream, "Release date", fontBold, fontSize, 1672f, y);
     spaceBetweenLines = 40f;
     for (ReportingDatasetVO dataset : receipt.getDatasets()) {
       y -= spaceBetweenLines + fontSize;
+      y = checkForPageChange(y);
       printLinePDF(contentStream, dataset.getNameDatasetSchema(), font, fontSize, 133f, y);
       text = dateTimeFormatter
           .format(ZonedDateTime.ofInstant(dataset.getDateReleased().toInstant(), timeZone))
@@ -240,9 +254,21 @@ public class ReceiptPDFGenerator {
     fontSize = 40f;
     x = 133f;
     y -= spaceBetweenLines * 4 - fontSize;
+    y = checkForPageChange(y);
     text = "Submitted by user: " + receipt.getEmail();
     printLinePDF(contentStream, text, font, fontSize, x, y);
     contentStream.close();
+  }
+
+  private float checkForPageChange(float newHeight) throws IOException {
+      if (newHeight <= 400) {
+        contentStream.close();
+        page = new PDPage(A4);
+        newHeight = 3334f;
+        document.addPage(page);
+        contentStream = new PDPageContentStream(document, page);
+      }
+      return newHeight;
   }
 
   /**


### PR DESCRIPTION
[https://taskman.eionet.europa.eu/issues/304930](url)

In dataflows with lots of dataset and big descriptions often the receipt cannot fit everything in one page. I modified ReceptPDFGenerator to split content of the receipt into multiple pages if it does not fit in a single one.