### PR TITLE
Bug #302968 - Bug in RN3, inconsistent internal data

### DIFF
--- a/dataset-service/src/main/java/org/eea/dataset/controller/DatasetSchemaControllerImpl.java
+++ b/dataset-service/src/main/java/org/eea/dataset/controller/DatasetSchemaControllerImpl.java
@@ -127,8 +127,6 @@ public class DatasetSchemaControllerImpl implements DatasetSchemaController {
   @Lazy
   @Autowired
   private BigDataDatasetService bigDataDatasetService;
-    @Autowired
-    private DataFlowControllerZuul dataFlowControllerZuul;
 
     /**
    * Creates the empty dataset schema.
@@ -584,10 +582,19 @@ public class DatasetSchemaControllerImpl implements DatasetSchemaController {
       if(Boolean.TRUE.equals(isBigDataFlow)){
         updateMaterializedViews = false;
       }
-      if (BooleanUtils.isTrue(isBigDataFlow) && !StringUtil.isNullOrEmpty(tableSchemaVO.getIdTableSchema())) {
+      //Deleting data from the old table and creating a new table should only occur when renaming a table, meaning when
+      //getNameTableSchema is not blank.
+      if (BooleanUtils.isTrue(isBigDataFlow)
+              && !StringUtil.isNullOrEmpty(tableSchemaVO.getIdTableSchema())
+              && StringUtils.isNotBlank(tableSchemaVO.getNameTableSchema())) {
         bigDataDatasetService.deleteTableData(datasetId, dataflowId, null, null, tableSchemaVO.getIdTableSchema(), null, false);
-      }
+       }
       dataschemaService.updateTableSchema(datasetId, tableSchemaVO, updateMaterializedViews);
+
+      //Creating an empty table for the new table name is required for ValidateQCs functionality to work correctly.
+      if (StringUtils.isNoneBlank(tableSchemaVO.getNameTableSchema())) {
+        bigDataDatasetService.createEmptyTablesForSpecificTableSchema(datasetId, tableSchemaVO.getIdTableSchema());
+      }
     } catch (EEAException e) {
       LOG.error("Error updating table schema for datasetId {}. Message: {}", datasetId, e.getMessage(), e);
       if (e.getMessage() != null

--- a/dataset-service/src/main/java/org/eea/dataset/service/BigDataDatasetService.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/BigDataDatasetService.java
@@ -372,4 +372,6 @@ public interface BigDataDatasetService {
      * @param s3PathResolver table resolver
      */
      boolean isTableEmpty(S3PathResolver s3PathResolver);
+
+     void createEmptyTablesForSpecificTableSchema(Long datasetId, String tableSchemaId) throws EEAException;
 }

--- a/dataset-service/src/main/java/org/eea/dataset/service/impl/BigDataDatasetServiceImpl.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/impl/BigDataDatasetServiceImpl.java
@@ -998,7 +998,9 @@ public class BigDataDatasetServiceImpl implements BigDataDatasetService {
                 }
             }
 
-            createEmptyTables.runCreationForSpecificTableSchema(dataSetMetabaseVO, tableSchemaId, preparationCode);
+            if (createEmptyTablesBool) {
+                createEmptyTables.runCreationForSpecificTableSchema(dataSetMetabaseVO, tableSchemaId, preparationCode);
+            }
 
             if (jobId != null) {
                 jobControllerZuul.updateJobStatus(jobId, JobStatusEnum.FINISHED);
@@ -3483,5 +3485,12 @@ public class BigDataDatasetServiceImpl implements BigDataDatasetService {
             LOG.warn("Could not query row count for table {}, treating as non-empty", s3PathResolver.getTableName(), e);
             return false;
         }
+    }
+
+    public void createEmptyTablesForSpecificTableSchema(Long datasetId, String tableSchemaId) throws EEAException {
+
+        final DataSetMetabaseVO dataSetMetabaseVO = datasetMetabaseService.findDatasetMetabase(datasetId);
+        createEmptyTables.runCreationForSpecificTableSchema(dataSetMetabaseVO, tableSchemaId);
+
     }
 }

--- a/dataset-service/src/test/java/org/eea/dataset/controller/DatasetSchemaControllerImplTest.java
+++ b/dataset-service/src/test/java/org/eea/dataset/controller/DatasetSchemaControllerImplTest.java
@@ -25,10 +25,7 @@ import org.eea.dataset.persistence.schemas.domain.DataSetSchema;
 import org.eea.dataset.persistence.schemas.domain.FieldSchema;
 import org.eea.dataset.persistence.schemas.domain.RecordSchema;
 import org.eea.dataset.persistence.schemas.domain.TableSchema;
-import org.eea.dataset.service.DatasetMetabaseService;
-import org.eea.dataset.service.DatasetService;
-import org.eea.dataset.service.DatasetSnapshotService;
-import org.eea.dataset.service.DesignDatasetService;
+import org.eea.dataset.service.*;
 import org.eea.dataset.service.impl.DataschemaServiceImpl;
 import org.eea.exception.EEAErrorMessage;
 import org.eea.exception.EEAException;
@@ -150,6 +147,9 @@ public class DatasetSchemaControllerImplTest {
   /** The notification controller zuul. */
   @Mock
   private NotificationControllerZuul notificationControllerZuul;
+
+  @Mock
+  private BigDataDatasetService bigDataDatasetServiceMock;
 
 
   /**


### PR DESCRIPTION
- Modified BigDataDatasetServiceImpl.deleteTableData() to use the createEmptyTablesBool parameter.
- Added BigDataDatasetServiceImpl.createEmptyTablesForSpecificTableSchema()
- Modified DatasetSchemaControllerImpl.updateTableSchema() to create empty tables when updating the schema of a table.
- Fixed a bug in updateTableSchema() introduced in #296998 where editing a design table's schema (i.e enabling/disabling editing) would delete the table's data.