### PR TITLE
Added providerName parameter for filtering and display on the Job Monitoring screen

### DIFF
--- a/common-interfaces/src/main/java/org/eea/interfaces/controller/dataflow/RepresentativeController.java
+++ b/common-interfaces/src/main/java/org/eea/interfaces/controller/dataflow/RepresentativeController.java
@@ -334,4 +334,7 @@ public interface RepresentativeController {
   @GetMapping(value = "/private/code/{code}/group/{groupId}", produces = MediaType.APPLICATION_JSON_VALUE)
   DataProviderVO findDataProviderByCodeAndGroupId(@PathVariable("code") String code, @PathVariable("groupId") Long groupId);
 
+  @GetMapping(value = "/private/providerName/{providerName}", produces = MediaType.APPLICATION_JSON_VALUE)
+  DataProviderVO findDataProviderByLabel(@PathVariable("providerName") String providerName);
+
 }

--- a/common-interfaces/src/main/java/org/eea/interfaces/controller/orchestrator/JobController.java
+++ b/common-interfaces/src/main/java/org/eea/interfaces/controller/orchestrator/JobController.java
@@ -33,6 +33,7 @@ public interface JobController {
      * @param dataflowId
      * @param dataflowName
      * @param providerId
+     * @param providerName
      * @param datasetId
      * @param datasetName
      * @param creatorUsername
@@ -50,6 +51,7 @@ public interface JobController {
             @RequestParam(value = "dataflowId", required = false) Long dataflowId,
             @RequestParam(value = "dataflowName", required = false) String dataflowName,
             @RequestParam(value = "providerId", required = false) Long providerId,
+            @RequestParam(value = "providerName", required = false) String providerName,
             @RequestParam(value = "datasetId", required = false) Long datasetId,
             @RequestParam(value = "datasetName", required = false) String datasetName,
             @RequestParam(value = "creatorUsername", required = false) String creatorUsername,

--- a/common-interfaces/src/main/java/org/eea/interfaces/controller/orchestrator/JobHistoryController.java
+++ b/common-interfaces/src/main/java/org/eea/interfaces/controller/orchestrator/JobHistoryController.java
@@ -48,6 +48,7 @@ public interface JobHistoryController {
             @RequestParam(value = "dataflowId", required = false) Long dataflowId,
             @RequestParam(value = "dataflowName", required = false) String dataflowName,
             @RequestParam(value = "providerId", required = false) Long providerId,
+            @RequestParam(value = "providerName", required = false) String providerName,
             @RequestParam(value = "datasetId", required = false) Long datasetId,
             @RequestParam(value = "datasetName", required = false) String datasetName,
             @RequestParam(value = "creatorUsername", required = false) String creatorUsername,

--- a/common-interfaces/src/main/java/org/eea/interfaces/vo/orchestrator/JobHistoryVO.java
+++ b/common-interfaces/src/main/java/org/eea/interfaces/vo/orchestrator/JobHistoryVO.java
@@ -55,6 +55,9 @@ public class JobHistoryVO implements Serializable {
     /** The data provider id */
     private Long providerId;
 
+    /** The data provider name */
+    private String providerName;
+
     /** The dataset id */
     private Long datasetId;
 

--- a/common-interfaces/src/main/java/org/eea/interfaces/vo/orchestrator/JobVO.java
+++ b/common-interfaces/src/main/java/org/eea/interfaces/vo/orchestrator/JobVO.java
@@ -52,6 +52,9 @@ public class JobVO implements Serializable {
     /** The data provider id */
     private Long providerId;
 
+    /** The data provider name */
+    private String providerName;
+
     /** The dataset id */
     private Long datasetId;
 

--- a/dataflow-service/src/main/java/org/eea/dataflow/controller/RepresentativeControllerImpl.java
+++ b/dataflow-service/src/main/java/org/eea/dataflow/controller/RepresentativeControllerImpl.java
@@ -953,4 +953,17 @@ public class RepresentativeControllerImpl implements RepresentativeController {
     }
   }
 
+  @Override
+  @GetMapping(value = "/private/providerName/{providerName}", produces = MediaType.APPLICATION_JSON_VALUE)
+  public DataProviderVO findDataProviderByLabel(
+          @ApiParam(value = "Provider name", example = "Austria") @PathVariable("providerName") String providerName) {
+    try{
+      return representativeService.findDataProviderByLabel(providerName);
+    }
+    catch (Exception e){
+      LOG.error("Could not find provider with name {} Error: {}", providerName, e.getMessage());
+      throw e;
+    }
+  }
+
 }

--- a/dataflow-service/src/main/java/org/eea/dataflow/persistence/repository/DataProviderRepository.java
+++ b/dataflow-service/src/main/java/org/eea/dataflow/persistence/repository/DataProviderRepository.java
@@ -58,4 +58,12 @@ public interface DataProviderRepository extends PagingAndSortingRepository<DataP
    */
   Optional<DataProvider> findFirstByCodeAndDataProviderGroup_id(String code, Long dataProviderGroup);
 
+  /**
+   * Find by label.
+   *
+   * @param providerName the provider label
+   * @return the optional
+   */
+  Optional<DataProvider> findFirstByLabel(String providerName);
+
 }

--- a/dataflow-service/src/main/java/org/eea/dataflow/service/RepresentativeService.java
+++ b/dataflow-service/src/main/java/org/eea/dataflow/service/RepresentativeService.java
@@ -294,4 +294,6 @@ public interface RepresentativeService {
   boolean checkDataHaveBeenRelease(Long dataflowId, Long dataProviderId) throws EEAException;
 
   DataProviderVO findDataProviderByCodeAndGroupId(String code, Long groupId);
+
+  DataProviderVO findDataProviderByLabel(String providerName);
 }

--- a/dataflow-service/src/main/java/org/eea/dataflow/service/impl/RepresentativeServiceImpl.java
+++ b/dataflow-service/src/main/java/org/eea/dataflow/service/impl/RepresentativeServiceImpl.java
@@ -1523,5 +1523,18 @@ public class RepresentativeServiceImpl implements RepresentativeService {
     else return null;
   }
 
+  /**
+   * Find data providers by label.
+   *
+   * @param providerName the provider label
+   * @return the list
+   */
+  public DataProviderVO findDataProviderByLabel(String providerName) {
+    Optional<DataProvider> dataProvider = dataProviderRepository.findFirstByLabel(providerName);
+    if (dataProvider.isPresent()) {
+      return dataProviderMapper.entityToClass(dataProvider.get());
+    }
+    else return null;
+  }
 
 }

--- a/dataset-service/src/main/java/org/eea/dataset/io/kafka/commands/CheckBlockersDataSnapshotCommand.java
+++ b/dataset-service/src/main/java/org/eea/dataset/io/kafka/commands/CheckBlockersDataSnapshotCommand.java
@@ -158,7 +158,7 @@ public class CheckBlockersDataSnapshotCommand extends AbstractEEAEventHandlerCom
         parameters.put("validationJobId", validationJobId);
       }
 
-      JobVO releaseJob = new JobVO(null, JobTypeEnum.RELEASE, JobStatusEnum.QUEUED, ts, ts, parameters, user, true, dataset.getDataflowId(), dataset.getDataProviderId(), null, null, dataflowName, null, null, null, null);
+      JobVO releaseJob = new JobVO(null, JobTypeEnum.RELEASE, JobStatusEnum.QUEUED, ts, ts, parameters, user, true, dataset.getDataflowId(), dataset.getDataProviderId(), null,null, null, dataflowName, null, null, null, null);
 
       waitForValidationJobIfInProgress(validationJobId, 2000);
 

--- a/dataset-service/src/test/java/org/eea/dataset/io/kafka/commands/CheckBlockersDataSnapshotCommandTest.java
+++ b/dataset-service/src/test/java/org/eea/dataset/io/kafka/commands/CheckBlockersDataSnapshotCommandTest.java
@@ -129,7 +129,7 @@ public class CheckBlockersDataSnapshotCommandTest {
             datasetMetabase.getDataflowId(), datasetMetabase.getDataProviderId()))
         .thenReturn(datasetsId);
     Mockito.when(jobControllerZuul.checkEligibilityOfJob(anyString(), anyBoolean(), anyLong(), anyLong(), anyList(), any())).thenReturn(JobStatusEnum.QUEUED);
-    JobVO jobVO = new JobVO(Long.valueOf(1), JobTypeEnum.RELEASE, JobStatusEnum.QUEUED, new Timestamp(System.currentTimeMillis()), new Timestamp(System.currentTimeMillis()), null, "test", true, 1L, 1L, 1L, null, null, null, null, null, null);
+    JobVO jobVO = new JobVO(Long.valueOf(1), JobTypeEnum.RELEASE, JobStatusEnum.QUEUED, new Timestamp(System.currentTimeMillis()), new Timestamp(System.currentTimeMillis()), null, "test", true, 1L, 1L, null,1L, null, null, null, null, null, null);
     Mockito.when(jobControllerZuul.save(any(JobVO.class))).thenReturn(jobVO);
     Mockito.doNothing().when(jobHistoryControllerZuul).save(any(JobVO.class));
     ProcessVO processVO = new ProcessVO();
@@ -167,7 +167,7 @@ public class CheckBlockersDataSnapshotCommandTest {
             datasetMetabase.getDataflowId(), datasetMetabase.getDataProviderId()))
         .thenReturn(datasetsId);
     Mockito.when(jobControllerZuul.checkEligibilityOfJob(anyString(), anyBoolean(), anyLong(), anyLong(), anyList(), any())).thenReturn(JobStatusEnum.QUEUED);
-    JobVO jobVO = new JobVO(Long.valueOf(1), JobTypeEnum.RELEASE, JobStatusEnum.QUEUED, new Timestamp(System.currentTimeMillis()), new Timestamp(System.currentTimeMillis()), null, "test", true, 1L, 1L, 1L, null, null, null, null, null, null);
+    JobVO jobVO = new JobVO(Long.valueOf(1), JobTypeEnum.RELEASE, JobStatusEnum.QUEUED, new Timestamp(System.currentTimeMillis()), new Timestamp(System.currentTimeMillis()), null, "test", true, 1L, 1L, "test",1L, null, null, null, null, null, null);
     Mockito.when(jobControllerZuul.save(any(JobVO.class))).thenReturn(jobVO);
     checkBlockersDataSnapshotCommand.execute(eeaEventVO);
     Mockito.verifyNoInteractions(validationRepository);

--- a/dataset-service/src/test/java/org/eea/dataset/service/ReleasePrecheckServiceTest.java
+++ b/dataset-service/src/test/java/org/eea/dataset/service/ReleasePrecheckServiceTest.java
@@ -70,7 +70,7 @@ public class ReleasePrecheckServiceTest {
     parameters.put("datasetId", Arrays.asList(750L));
     parameters.put("validationJobId", 1892);
 
-    JobVO releaseJob = new JobVO(1947L, null, null, new Timestamp(System.currentTimeMillis()), new Timestamp(System.currentTimeMillis()), parameters, "user1", true, 61L, 2L, null, null, null, null, null, null, null);
+    JobVO releaseJob = new JobVO(1947L, null, null, new Timestamp(System.currentTimeMillis()), new Timestamp(System.currentTimeMillis()), parameters, "user1", true, 61L, 2L, null,null, null, null, null, null, null, null);
 
     Mockito.when(jobControllerZuul.findJobById(1947L)).thenReturn(releaseJob);
     Mockito.when(dataFlowControllerZuul.isBigDataflow(61L)).thenReturn(false);

--- a/orchestrator-service/src/main/java/org/eea/orchestrator/controller/JobControllerImpl.java
+++ b/orchestrator-service/src/main/java/org/eea/orchestrator/controller/JobControllerImpl.java
@@ -91,7 +91,7 @@ public class JobControllerImpl implements JobController {
     private JobUtils jobUtils;
 
     /** The valid columns. */
-    List<String> validColumns = Arrays.asList("jobId", "creatorUsername", "jobType", "dataflowId", "providerId", "datasetId",
+    List<String> validColumns = Arrays.asList("jobId", "creatorUsername", "jobType", "dataflowId", "providerId", "providerName", "datasetId",
             "jobStatus", "dateAdded", "dateStatusChanged", "fmeJobId", "dataflowName", "datasetName");
 
     private static final String FILE_PATTERN_NAME_V2 = "etlExport_%s";
@@ -119,6 +119,7 @@ public class JobControllerImpl implements JobController {
             @RequestParam(value = "dataflowId", required = false) Long dataflowId,
             @RequestParam(value = "dataflowName", required = false) String dataflowName,
             @RequestParam(value = "providerId", required = false) Long providerId,
+            @RequestParam(value = "providerName", required = false) String providerName,
             @RequestParam(value = "datasetId", required = false) Long datasetId,
             @RequestParam(value = "datasetName", required = false) String datasetName,
             @RequestParam(value = "creatorUsername", required = false) String creatorUsername,
@@ -131,7 +132,7 @@ public class JobControllerImpl implements JobController {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Wrong sorting header provided.");
             }
             return jobService.getJobs(pageable, asc, sortedColumn, jobId, jobTypes, dataflowId, dataflowName,
-                    providerId, datasetId, datasetName, creatorUsername, jobStatuses, preparationCode);
+                    providerId, providerName, datasetId, datasetName, creatorUsername, jobStatuses, preparationCode);
         } catch (Exception e){
             LOG.error("Unexpected error! Could not retrieve all jobs");
             throw e;

--- a/orchestrator-service/src/main/java/org/eea/orchestrator/controller/JobHistoryControllerImpl.java
+++ b/orchestrator-service/src/main/java/org/eea/orchestrator/controller/JobHistoryControllerImpl.java
@@ -57,6 +57,7 @@ public class JobHistoryControllerImpl implements JobHistoryController {
             @RequestParam(value = "dataflowId", required = false) Long dataflowId,
             @RequestParam(value = "dataflowName", required = false) String dataflowName,
             @RequestParam(value = "providerId", required = false) Long providerId,
+            @RequestParam(value = "providerName", required = false) String providerName,
             @RequestParam(value = "datasetId", required = false) Long datasetId,
             @RequestParam(value = "datasetName", required = false) String datasetName,
             @RequestParam(value = "creatorUsername", required = false) String creatorUsername,

--- a/orchestrator-service/src/main/java/org/eea/orchestrator/service/JobService.java
+++ b/orchestrator-service/src/main/java/org/eea/orchestrator/service/JobService.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 public interface JobService {
-    JobsVO getJobs(Pageable pageable, boolean asc, String sortedColumn, Long jobId, String jobTypes, Long dataflowId, String dataflowName, Long providerId,
+    JobsVO getJobs(Pageable pageable, boolean asc, String sortedColumn, Long jobId, String jobTypes, Long dataflowId, String dataflowName, Long providerId, String providerName,
                    Long datasetId, String datasetName, String creatorUsername, String jobStatuses, String preparationCode);
 
     List<JobVO> getJobsByStatus(JobStatusEnum status);

--- a/orchestrator-service/src/main/java/org/eea/orchestrator/service/impl/JobServiceImpl.java
+++ b/orchestrator-service/src/main/java/org/eea/orchestrator/service/impl/JobServiceImpl.java
@@ -58,6 +58,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.eea.utils.LiteralConstants.*;
 
@@ -154,13 +155,30 @@ public class JobServiceImpl implements JobService {
     private static final String CANCELED_BY_ADMIN_ERROR = "cancelled by admin";
 
     @Override
-    public JobsVO getJobs(Pageable pageable, boolean asc, String sortedColumn, Long jobId, String jobTypes, Long dataflowId, String dataflowName, Long providerId,
+    public JobsVO getJobs(Pageable pageable, boolean asc, String sortedColumn, Long jobId, String jobTypes, Long dataflowId, String dataflowName, Long providerId, String providerName,
                           Long datasetId, String datasetName, String creatorUsername, String jobStatuses, String preparationCode) {
 
         String sortedTableColumn = jobUtils.getJobColumnNameByObjectName(sortedColumn);
         String remainingJobsStatusFilter = "IN_PROGRESS,QUEUED";
+        // Resolve the human-readable providerName filter (from the request) into the internal providerId
+        // used by the query, since jobs store providerId, not provider label.
+        if (StringUtils.isNotBlank(providerName)) {
+            DataProviderVO dataProvider = representativeControllerZuul.findDataProviderByLabel(providerName);
+            if (dataProvider != null) {
+                providerId = dataProvider.getId();
+            } else {
+                // No provider matches the given providerName, so the filter can never match any real job.
+                // Force jobId to a sentinel value (0L, an id that can never exist) to guarantee the
+                // downstream query returns an empty result set.
+                // Without this, an unmatched providerName would be silently ignored and the query would
+                // fall back to fetching ALL jobs - returning incorrect, unfiltered results to the caller.
+                jobId = 0L;
+            }
+        }
         List<Job> jobs = jobRepository.findJobsPaginated(pageable, asc, sortedTableColumn, jobId, jobTypes, dataflowId, dataflowName, providerId, datasetId, datasetName, creatorUsername, jobStatuses, preparationCode);
         List<JobVO> jobVOList = jobMapper.entityListToClass(jobs);
+
+        populateProviderNames(jobVOList);
         JobsVO jobsVO = new JobsVO();
         jobsVO.setTotalRecords(jobRepository.count());
         jobsVO.setFilteredRecords(jobRepository.countJobsPaginated(asc, sortedTableColumn, jobId, jobTypes, dataflowId, dataflowName, providerId, datasetId, datasetName, creatorUsername, jobStatuses));
@@ -946,5 +964,26 @@ public class JobServiceImpl implements JobService {
                 dataSetSnapshotControllerZuul.releaseLocksFromReleaseDatasets(job.getDataflowId(), job.getProviderId());
             }
         }
+    }
+
+    /**
+     * Enriches each JobVO with its provider's display name.
+     * providerId has no DB foreign key to the provider table, so the name must be resolved via a separate call rather than a SQL join.
+     * Resolved in a single batch call (rather than per-row) to avoid an N+1 remote-call problem against the representative service.
+     */
+    private void populateProviderNames(List<JobVO> jobVOList) {
+        List<Long> providerIds = jobVOList.stream()
+                .map(JobVO::getProviderId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        if (providerIds.isEmpty()) {
+            return;
+        }
+
+        Map<Long, String> labelById = representativeControllerZuul.findDataProvidersByIds(providerIds).stream()
+                .collect(Collectors.toMap(DataProviderVO::getId, DataProviderVO::getLabel));
+
+        jobVOList.forEach(job -> job.setProviderName(labelById.get(job.getProviderId())));
     }
 }


### PR DESCRIPTION
This change adds support for filtering and displaying jobs by data provider name (in addition to the existing providerId) on the job monitoring screen.