### PR TITLE
Custodian emails for started/ended/failed release jobs #306166

### DIFF
--- a/common-utitlities/src/main/java/org/eea/utils/LiteralConstants.java
+++ b/common-utitlities/src/main/java/org/eea/utils/LiteralConstants.java
@@ -167,6 +167,18 @@ public final class LiteralConstants {
   public static final String RELEASEMESSAGE =
       "This automatic notification informs that %s has successfully released in %s on %s (CET).";
 
+  /** The Constant RELEASE_STARTED_SUBJECT. */
+  public static final String RELEASE_STARTED_SUBJECT = "%s started a release for %s";
+
+  /** The Constant RELEASE_STARTED_MESSAGE. */
+  public static final String RELEASE_STARTED_MESSAGE = "This automatic notification informs that %s started the release process for dataflow %s on %s (CET).";
+
+  /** The Constant RELEASE_FAILED_SUBJECT. */
+  public static final String RELEASE_FAILED_SUBJECT = "%s failed to release for %s";
+
+  /** The Constant RELEASE_FAILED_MESSAGE. */
+  public static final String RELEASE_FAILED_MESSAGE = "This automatic notification informs that %s failed to release for dataflow %s on %s (CET). Reason: %s";
+
   /** The Constant GEOMETRYERROR. : {@value} */
   public static final String GEOMETRYERROR =
       "The value does not follow the expected syntax for a valid ";

--- a/dataset-service/src/main/java/org/eea/dataset/io/kafka/commands/ReleaseDataSnapshotsCommand.java
+++ b/dataset-service/src/main/java/org/eea/dataset/io/kafka/commands/ReleaseDataSnapshotsCommand.java
@@ -7,6 +7,7 @@ import org.eea.dataset.persistence.metabase.repository.ChangesEUDatasetRepositor
 import org.eea.dataset.persistence.metabase.repository.DataCollectionRepository;
 import org.eea.dataset.service.DatasetMetabaseService;
 import org.eea.dataset.service.DatasetSnapshotService;
+import org.eea.dataset.service.ReleaseEmailService;
 import org.eea.dataset.service.helper.FileTreatmentHelper;
 import org.eea.exception.EEAException;
 import org.eea.interfaces.controller.collaboration.CollaborationController.CollaborationControllerZuul;
@@ -108,6 +109,9 @@ public class ReleaseDataSnapshotsCommand extends AbstractEEAEventHandlerCommand 
   /** The job controller zuul */
   @Autowired
   private JobControllerZuul jobControllerZuul;
+
+  @Autowired
+  private ReleaseEmailService releaseEmailService;
 
   /**
    * The Constant LOG.
@@ -233,7 +237,7 @@ public class ReleaseDataSnapshotsCommand extends AbstractEEAEventHandlerCommand 
 
         if(!silentRelease) {
           // Send email to requesters
-          sendMail(dateRelease, dataset, dataflowVO);
+          releaseEmailService.sendReleaseFinishedEmail(dateRelease, dataset, dataflowVO);
         }
 
         LOG.info("Releasing datasets process ends. DataflowId: {} DataProviderId: {} DatasetId: {}, JobId: {}",
@@ -294,58 +298,4 @@ public class ReleaseDataSnapshotsCommand extends AbstractEEAEventHandlerCommand 
     }
   }
 
-
-  /**
-   * Send mail.
-   *
-   * @param dateRelease the date release
-   * @param dataset the dataset
-   * @param dataflowVO the dataflow VO
-   */
-  private void sendMail(String dateRelease, DataSetMetabaseVO dataset, DataFlowVO dataflowVO) {
-    try {
-      // get custodian and stewards emails
-      List<UserRepresentationVO> custodians = userManagementControllerZuul
-              .getUsersByGroup(ResourceGroupEnum.DATAFLOW_CUSTODIAN.getGroupName(dataflowVO.getId()));
-      List<UserRepresentationVO> stewards = userManagementControllerZuul
-              .getUsersByGroup(ResourceGroupEnum.DATAFLOW_STEWARD.getGroupName(dataflowVO.getId()));
-      List<UserRepresentationVO> observers = userManagementControllerZuul
-              .getUsersByGroup(ResourceGroupEnum.DATAFLOW_OBSERVER.getGroupName(dataflowVO.getId()));
-      List<UserRepresentationVO> custodianSupport = userManagementControllerZuul.getUsersByGroup(
-              ResourceGroupEnum.DATAFLOW_STEWARD_SUPPORT.getGroupName(dataflowVO.getId()));
-      List<String> emails = new ArrayList<>();
-      if (null != custodians) {
-        custodians.stream().forEach(custodian -> emails.add(custodian.getEmail()));
-      }
-      if (null != stewards) {
-        stewards.stream().forEach(steward -> emails.add(steward.getEmail()));
-      }
-      if (null != observers) {
-        observers.stream().forEach(observer -> emails.add(observer.getEmail()));
-      }
-      if (null != custodianSupport) {
-        custodianSupport.stream().forEach(support -> emails.add(support.getEmail()));
-      }
-
-      EmailVO emailVO = new EmailVO();
-      emailVO.setBbc(emails);
-      emailVO.setSubject(String.format(LiteralConstants.RELEASESUBJECT, dataset.getDataSetName(),
-              dataflowVO.getName()));
-
-      //force date description to CET
-      DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-      LocalDateTime utcDateTime = LocalDateTime.parse(dateRelease, formatter);
-      ZonedDateTime utcZoned = utcDateTime.atZone(ZoneOffset.UTC);
-      ZonedDateTime cetZoned = utcZoned.withZoneSameInstant(ZoneId.of(LiteralConstants.EUROPE_ZONE_ID));
-      String cetDate = cetZoned.format(formatter);
-
-      emailVO.setText(String.format(LiteralConstants.RELEASEMESSAGE, dataset.getDataSetName(),
-              dataflowVO.getName(), cetDate));
-      emailControllerZuul.sendMessage(emailVO);
-    } catch (Exception e) {
-      Long dataflowId = (dataflowVO != null) ? dataflowVO.getId() : null;
-      Long datasetId = (dataflowVO != null) ? dataset.getId() : null;
-      LOG.error("Unexpected error! Error sending release mail for dataflowId {} and datasetId {}. Message: {}", dataflowId, datasetId, e.getMessage());
-    }
-  }
 }

--- a/dataset-service/src/main/java/org/eea/dataset/io/notification/events/ReleaseDatasetSnapshotFailedEvent.java
+++ b/dataset-service/src/main/java/org/eea/dataset/io/notification/events/ReleaseDatasetSnapshotFailedEvent.java
@@ -2,6 +2,8 @@ package org.eea.dataset.io.notification.events;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import org.eea.dataset.service.ReleaseEmailService;
 import org.eea.exception.EEAException;
 import org.eea.interfaces.controller.dataset.DatasetMetabaseController.DataSetMetabaseControllerZuul;
 import org.eea.interfaces.controller.dataset.DatasetSnapshotController;
@@ -25,6 +27,8 @@ public class ReleaseDatasetSnapshotFailedEvent implements NotificableEventHandle
   @Autowired
   private DatasetSnapshotController datasetSnapshotController;
 
+  @Autowired
+  private ReleaseEmailService releaseEmailService;
 
   /**
    * Gets the event type.
@@ -54,6 +58,9 @@ public class ReleaseDatasetSnapshotFailedEvent implements NotificableEventHandle
     notification.put("snapshotId", snapshotId);
     notification.put("snapshotName", datasetName);
     notification.put("error", notificationVO.getError());
+
+    // Send the notification error message to ReleaseEmailService so it can be included the failure email.
+    releaseEmailService.sendReleaseFailedEmail(notificationVO.getDataflowId(), notificationVO.getProviderId(), notificationVO.getError());
 
     datasetSnapshotController.rollBackSnapshotRecord(notificationVO.getJobId(), notificationVO.getDataflowId(), notificationVO.getProviderId());
     return notification;

--- a/dataset-service/src/main/java/org/eea/dataset/io/notification/events/ReleaseFailedDatasetLockedForEditingExistsEvent.java
+++ b/dataset-service/src/main/java/org/eea/dataset/io/notification/events/ReleaseFailedDatasetLockedForEditingExistsEvent.java
@@ -1,5 +1,6 @@
 package org.eea.dataset.io.notification.events;
 
+import org.eea.dataset.service.ReleaseEmailService;
 import org.eea.exception.EEAException;
 import org.eea.interfaces.controller.dataflow.DataFlowController;
 import org.eea.interfaces.controller.dataflow.RepresentativeController;
@@ -25,6 +26,9 @@ public class ReleaseFailedDatasetLockedForEditingExistsEvent implements Notifica
     /** The dataflow controller zuul. */
     @Autowired
     private DataFlowController.DataFlowControllerZuul dataFlowControllerZuul;
+
+    @Autowired
+    private ReleaseEmailService releaseEmailService;
 
     /**
      * Gets the event type.
@@ -53,9 +57,12 @@ public class ReleaseFailedDatasetLockedForEditingExistsEvent implements Notifica
         String dataProviderLabel = "";
         if (null != providerId) {
             DataProviderVO dataProviderVO =
-                    representativeControllerZuul.findDataProviderById(notificationVO.getProviderId());
+                representativeControllerZuul.findDataProviderById(notificationVO.getProviderId());
             dataProviderLabel = dataProviderVO.getLabel();
         }
+
+        // Send the notification error message to ReleaseEmailService so it can be included the failure email.
+        releaseEmailService.sendReleaseFailedEmail(dataflowId, providerId, notificationVO.getError());
 
         Map<String, Object> notification = new HashMap<>();
         notification.put("user", notificationVO.getUser());

--- a/dataset-service/src/main/java/org/eea/dataset/io/notification/events/ReleaseFailedIcebergExistsEvent.java
+++ b/dataset-service/src/main/java/org/eea/dataset/io/notification/events/ReleaseFailedIcebergExistsEvent.java
@@ -1,5 +1,6 @@
 package org.eea.dataset.io.notification.events;
 
+import org.eea.dataset.service.ReleaseEmailService;
 import org.eea.exception.EEAException;
 import org.eea.interfaces.controller.dataflow.DataFlowController;
 import org.eea.interfaces.controller.dataflow.RepresentativeController;
@@ -25,6 +26,9 @@ public class ReleaseFailedIcebergExistsEvent implements NotificableEventHandler 
     /** The dataflow controller zuul. */
     @Autowired
     private DataFlowController.DataFlowControllerZuul dataFlowControllerZuul;
+
+    @Autowired
+    private ReleaseEmailService releaseEmailService;
 
     /**
      * Gets the event type.
@@ -53,9 +57,12 @@ public class ReleaseFailedIcebergExistsEvent implements NotificableEventHandler 
         String dataProviderLabel = "";
         if (null != providerId) {
             DataProviderVO dataProviderVO =
-                    representativeControllerZuul.findDataProviderById(notificationVO.getProviderId());
+                representativeControllerZuul.findDataProviderById(notificationVO.getProviderId());
             dataProviderLabel = dataProviderVO.getLabel();
         }
+
+        // Send the notification error message to ReleaseEmailService so it can be included the failure email.
+        releaseEmailService.sendReleaseFailedEmail(dataflowId, providerId, notificationVO.getError());
 
         Map<String, Object> notification = new HashMap<>();
         notification.put("user", notificationVO.getUser());

--- a/dataset-service/src/main/java/org/eea/dataset/io/notification/events/ReleaseRefusedEvent.java
+++ b/dataset-service/src/main/java/org/eea/dataset/io/notification/events/ReleaseRefusedEvent.java
@@ -1,5 +1,6 @@
 package org.eea.dataset.io.notification.events;
 
+import org.eea.dataset.service.ReleaseEmailService;
 import org.eea.exception.EEAException;
 import org.eea.interfaces.controller.dataflow.DataFlowController;
 import org.eea.interfaces.controller.dataflow.RepresentativeController;
@@ -25,6 +26,9 @@ public class ReleaseRefusedEvent implements NotificableEventHandler {
     /** The dataflow controller zuul. */
     @Autowired
     private DataFlowController.DataFlowControllerZuul dataFlowControllerZuul;
+
+    @Autowired
+    private ReleaseEmailService releaseEmailService;
 
     /**
      * Gets the event type.
@@ -53,9 +57,12 @@ public class ReleaseRefusedEvent implements NotificableEventHandler {
         String dataProviderLabel = "";
         if (null != providerId) {
             DataProviderVO dataProviderVO =
-                    representativeControllerZuul.findDataProviderById(notificationVO.getProviderId());
+                representativeControllerZuul.findDataProviderById(notificationVO.getProviderId());
             dataProviderLabel = dataProviderVO.getLabel();
         }
+
+        // Send the notification error message to ReleaseEmailService so it can be included the failure email.
+        releaseEmailService.sendReleaseFailedEmail(dataflowId, providerId, notificationVO.getError());
 
         Map<String, Object> notification = new HashMap<>();
         notification.put("user", notificationVO.getUser());

--- a/dataset-service/src/main/java/org/eea/dataset/io/notification/events/ReleaseValidationBlockersFailEvent.java
+++ b/dataset-service/src/main/java/org/eea/dataset/io/notification/events/ReleaseValidationBlockersFailEvent.java
@@ -3,6 +3,7 @@ package org.eea.dataset.io.notification.events;
 import java.util.HashMap;
 import java.util.Map;
 import org.eea.dataset.service.DatasetService;
+import org.eea.dataset.service.ReleaseEmailService;
 import org.eea.exception.EEAException;
 import org.eea.kafka.domain.EventType;
 import org.eea.kafka.domain.NotificationVO;
@@ -19,6 +20,9 @@ public class ReleaseValidationBlockersFailEvent implements NotificableEventHandl
 
   @Autowired
   private DatasetService datasetService;
+
+  @Autowired
+  private ReleaseEmailService releaseEmailService;
 
   /**
    * Gets the event type.
@@ -41,6 +45,9 @@ public class ReleaseValidationBlockersFailEvent implements NotificableEventHandl
   public Map<String, Object> getMap(NotificationVO notificationVO) throws EEAException {
     Long dataflowId = notificationVO.getDataflowId() != null ? notificationVO.getDataflowId()
         : datasetService.getDataFlowIdById(notificationVO.getDatasetId());
+
+    // Send the notification error message to ReleaseEmailService so it can be included the failure email.
+    releaseEmailService.sendReleaseFailedEmail(dataflowId, notificationVO.getProviderId(), notificationVO.getError());
 
     Map<String, Object> notification = new HashMap<>();
     notification.put("user", notificationVO.getUser());

--- a/dataset-service/src/main/java/org/eea/dataset/service/ReleaseEmailService.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/ReleaseEmailService.java
@@ -1,0 +1,35 @@
+package org.eea.dataset.service;
+
+import org.eea.interfaces.vo.dataflow.DataFlowVO;
+import org.eea.interfaces.vo.dataset.DataSetMetabaseVO;
+
+public interface ReleaseEmailService {
+
+  /**
+   * Sends the email notification when a release has finished successfully.
+   *
+   * @param dateRelease the release date
+   * @param dataset the dataset
+   * @param dataflowVO the dataflow
+   */
+  void sendReleaseFinishedEmail(String dateRelease, DataSetMetabaseVO dataset, DataFlowVO dataflowVO);
+
+  /**
+   * Sends the email notification when a release has started.
+   *
+   * @param dataflowId the dataflow
+   * @param providerId the dataflow
+   */
+  void sendReleaseStartedEmail(Long dataflowId, Long providerId);
+
+  /**
+   * Sends the email notification when a release has started.
+   *
+   * @param dataflowId the dataflow id
+   * @param providerId the provider id
+   * @param reason the reason message
+   */
+  void sendReleaseFailedEmail(Long dataflowId, Long providerId, String reason);
+}
+
+

--- a/dataset-service/src/main/java/org/eea/dataset/service/ReleasePrecheckService.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/ReleasePrecheckService.java
@@ -13,13 +13,11 @@ import org.eea.interfaces.controller.orchestrator.JobProcessController.JobProces
 import org.eea.interfaces.controller.recordstore.ProcessController.ProcessControllerZuul;
 import org.eea.interfaces.vo.dataset.CreateSnapshotVO;
 import org.eea.interfaces.vo.dataset.DataSetMetabaseVO;
-import org.eea.interfaces.vo.dataset.enums.ErrorTypeEnum;
 import org.eea.interfaces.vo.orchestrator.JobProcessVO;
 import org.eea.interfaces.vo.orchestrator.JobVO;
 import org.eea.interfaces.vo.orchestrator.enums.JobInfoEnum;
 import org.eea.interfaces.vo.recordstore.enums.ProcessStatusEnum;
 import org.eea.interfaces.vo.recordstore.enums.ProcessTypeEnum;
-import org.eea.multitenancy.TenantResolver;
 import org.eea.thread.ThreadPropertiesManager;
 import org.eea.utils.LiteralConstants;
 import org.slf4j.Logger;
@@ -88,6 +86,9 @@ public class ReleasePrecheckService {
 
   @Autowired
   private DatasetService datasetService;
+
+  @Autowired
+  private ReleaseEmailService releaseEmailService;
 
   // Default priority used when the first real RELEASE process is created.
   private int defaultReleaseProcessPriority = 20;
@@ -227,6 +228,10 @@ public class ReleasePrecheckService {
         user,
         defaultReleaseProcessPriority,
         true);
+
+    if (Boolean.TRUE.equals(isProcessCreated)) {
+      releaseEmailService.sendReleaseStartedEmail(dataset.getDataflowId(), dataset.getDataProviderId());
+    }
 
     LOG.info("Created the first release process for dataflowId {}, dataProviderId {}, jobId {} and processId {} dataset id {} success: {}",
         dataset.getDataflowId(), dataset.getDataProviderId(), releaseJob.getId(), processId, firstDatasetId, isProcessCreated);

--- a/dataset-service/src/main/java/org/eea/dataset/service/impl/ReleaseEmailServiceImpl.java
+++ b/dataset-service/src/main/java/org/eea/dataset/service/impl/ReleaseEmailServiceImpl.java
@@ -1,0 +1,161 @@
+package org.eea.dataset.service.impl;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eea.dataset.service.ReleaseEmailService;
+import org.eea.interfaces.controller.communication.EmailController.EmailControllerZuul;
+import org.eea.interfaces.controller.dataflow.DataFlowController.DataFlowControllerZuul;
+import org.eea.interfaces.controller.dataflow.RepresentativeController.RepresentativeControllerZuul;
+import org.eea.interfaces.controller.ums.UserManagementController.UserManagementControllerZull;
+import org.eea.interfaces.vo.communication.EmailVO;
+import org.eea.interfaces.vo.dataflow.DataFlowVO;
+import org.eea.interfaces.vo.dataflow.DataProviderVO;
+import org.eea.interfaces.vo.dataset.DataSetMetabaseVO;
+import org.eea.interfaces.vo.ums.UserRepresentationVO;
+import org.eea.interfaces.vo.ums.enums.ResourceGroupEnum;
+import org.eea.utils.LiteralConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReleaseEmailServiceImpl implements ReleaseEmailService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ReleaseEmailServiceImpl.class);
+
+  @Autowired
+  private EmailControllerZuul emailControllerZuul;
+
+  @Autowired
+  private UserManagementControllerZull userManagementControllerZuul;
+
+  @Autowired
+  private DataFlowControllerZuul dataFlowControllerZuul;
+
+  @Autowired
+  private RepresentativeControllerZuul representativeControllerZuul;
+
+  @Override
+  public void sendReleaseFinishedEmail(String dateRelease, DataSetMetabaseVO dataset,
+                                       DataFlowVO dataflowVO) {
+    try {
+      // get custodian and stewards emails
+      List<UserRepresentationVO> custodians = userManagementControllerZuul.getUsersByGroup(
+          ResourceGroupEnum.DATAFLOW_CUSTODIAN.getGroupName(dataflowVO.getId()));
+      List<UserRepresentationVO> stewards = userManagementControllerZuul.getUsersByGroup(
+          ResourceGroupEnum.DATAFLOW_STEWARD.getGroupName(dataflowVO.getId()));
+      List<UserRepresentationVO> observers = userManagementControllerZuul.getUsersByGroup(
+          ResourceGroupEnum.DATAFLOW_OBSERVER.getGroupName(dataflowVO.getId()));
+      List<UserRepresentationVO> custodianSupport = userManagementControllerZuul.getUsersByGroup(
+          ResourceGroupEnum.DATAFLOW_STEWARD_SUPPORT.getGroupName(dataflowVO.getId()));
+      List<String> emails = new ArrayList<>();
+
+      if (null != custodians) {
+        custodians.forEach(custodian -> emails.add(custodian.getEmail()));
+      }
+
+      if (null != stewards) {
+        stewards.forEach(steward -> emails.add(steward.getEmail()));
+      }
+
+      if (null != observers) {
+        observers.forEach(observer -> emails.add(observer.getEmail()));
+      }
+
+      if (null != custodianSupport) {
+        custodianSupport.forEach(support -> emails.add(support.getEmail()));
+      }
+
+      EmailVO emailVO = new EmailVO();
+      emailVO.setBbc(emails);
+      emailVO.setSubject(String.format(LiteralConstants.RELEASESUBJECT, dataset.getDataSetName(), dataflowVO.getName()));
+
+      // force date description to CET
+      DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+      LocalDateTime utcDateTime = LocalDateTime.parse(dateRelease, formatter);
+      ZonedDateTime utcZoned = utcDateTime.atZone(ZoneOffset.UTC);
+      ZonedDateTime cetZoned = utcZoned.withZoneSameInstant(ZoneId.of(LiteralConstants.EUROPE_ZONE_ID));
+      String cetDate = cetZoned.format(formatter);
+      emailVO.setText(String.format(LiteralConstants.RELEASEMESSAGE, dataset.getDataSetName(), dataflowVO.getName(), cetDate));
+      emailControllerZuul.sendMessage(emailVO);
+    } catch (Exception e) {
+      Long dataflowId = dataflowVO != null ? dataflowVO.getId() : null;
+      Long datasetId = dataset != null ? dataset.getId() : null;
+      LOG.error("Unexpected error! Error sending release finished mail for dataflowId {} and datasetId {}. Message: {}",
+          dataflowId, datasetId, e.getMessage());
+    }
+  }
+
+  @Override
+  public void sendReleaseStartedEmail(Long dataflowId, Long providerId) {
+    try {
+      DataFlowVO dataflowVO = dataFlowControllerZuul.getMetabaseById(dataflowId);
+      String providerName = "";
+
+      if (providerId != null) {
+        DataProviderVO provider = representativeControllerZuul.findDataProviderById(providerId);
+        providerName = provider.getLabel();
+      }
+
+      String date = ZonedDateTime.now(ZoneId.of(LiteralConstants.EUROPE_ZONE_ID))
+          .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+      List<UserRepresentationVO> custodians = userManagementControllerZuul.getUsersByGroup(
+          ResourceGroupEnum.DATAFLOW_CUSTODIAN.getGroupName(dataflowVO.getId()));
+      List<String> emails = new ArrayList<>();
+
+      if (custodians != null) {
+        custodians.forEach(custodian -> emails.add(custodian.getEmail()));
+      }
+
+      EmailVO emailVO = new EmailVO();
+      emailVO.setBbc(emails);
+      emailVO.setSubject(String.format(LiteralConstants.RELEASE_STARTED_SUBJECT, providerName, dataflowVO.getName()));
+      emailVO.setText(String.format(LiteralConstants.RELEASE_STARTED_MESSAGE, providerName, dataflowVO.getName(), date));
+      emailControllerZuul.sendMessage(emailVO);
+    } catch (Exception e) {
+      LOG.error("Unexpected error! Error sending release started mail for dataflowId {}. Message: {}",
+          dataflowId, e.getMessage());
+    }
+  }
+
+  @Override
+  public void sendReleaseFailedEmail(Long dataflowId, Long providerId, String reason) {
+    try {
+      DataFlowVO dataflowVO = dataFlowControllerZuul.getMetabaseById(dataflowId);
+
+      String providerName = "";
+      if (providerId != null) {
+        DataProviderVO provider = representativeControllerZuul.findDataProviderById(providerId);
+        providerName = provider.getLabel();
+      }
+
+      String date = ZonedDateTime.now(ZoneId.of(LiteralConstants.EUROPE_ZONE_ID))
+          .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+      List<UserRepresentationVO> custodians = userManagementControllerZuul.getUsersByGroup(
+          ResourceGroupEnum.DATAFLOW_CUSTODIAN.getGroupName(dataflowId));
+      List<String> emails = new ArrayList<>();
+
+      if (custodians != null) {
+        custodians.forEach(custodian -> emails.add(custodian.getEmail()));
+      }
+
+      EmailVO emailVO = new EmailVO();
+      emailVO.setBbc(emails);
+      emailVO.setSubject(String.format(LiteralConstants.RELEASE_FAILED_SUBJECT, providerName, dataflowVO.getName()));
+      emailVO.setText(String.format(LiteralConstants.RELEASE_FAILED_MESSAGE, providerName, dataflowVO.getName(), date, reason));
+      emailControllerZuul.sendMessage(emailVO);
+    } catch (Exception e) {
+      LOG.error("Unexpected error! Error sending release failed mail for dataflowId {}. Message: {}",
+          dataflowId, e.getMessage());
+    }
+  }
+
+}
+

--- a/dataset-service/src/test/java/org/eea/dataset/io/kafka/commands/ReleaseDataSnapshotsCommandTest.java
+++ b/dataset-service/src/test/java/org/eea/dataset/io/kafka/commands/ReleaseDataSnapshotsCommandTest.java
@@ -5,6 +5,7 @@ import org.eea.dataset.persistence.metabase.repository.DataCollectionRepository;
 import org.eea.dataset.persistence.metabase.repository.DataSetMetabaseRepository;
 import org.eea.dataset.service.DatasetMetabaseService;
 import org.eea.dataset.service.DatasetSnapshotService;
+import org.eea.dataset.service.ReleaseEmailService;
 import org.eea.exception.EEAException;
 import org.eea.interfaces.controller.collaboration.CollaborationController.CollaborationControllerZuul;
 import org.eea.interfaces.controller.communication.EmailController.EmailControllerZuul;
@@ -90,6 +91,9 @@ public class ReleaseDataSnapshotsCommandTest {
 
   @Mock
   private JobProcessControllerZuul jobProcessControllerZuul;
+
+  @Mock
+  private ReleaseEmailService releaseEmailService;
 
   /** The eea event VO. */
   private EEAEventVO eeaEventVO;

--- a/dataset-service/src/test/java/org/eea/dataset/io/notification/events/ReleaseDatasetSnapshotFailedEventTest.java
+++ b/dataset-service/src/test/java/org/eea/dataset/io/notification/events/ReleaseDatasetSnapshotFailedEventTest.java
@@ -1,5 +1,6 @@
 package org.eea.dataset.io.notification.events;
 
+import org.eea.dataset.service.ReleaseEmailService;
 import org.eea.exception.EEAException;
 import org.eea.interfaces.controller.dataset.DatasetMetabaseController.DataSetMetabaseControllerZuul;
 import org.eea.interfaces.controller.dataset.DatasetSnapshotController;
@@ -29,7 +30,8 @@ public class ReleaseDatasetSnapshotFailedEventTest {
   @Mock
   private DatasetSnapshotController datasetSnapshotController;
 
-
+  @Mock
+  private ReleaseEmailService releaseEmailService;
 
   @Before
   public void initMocks() {

--- a/dataset-service/src/test/java/org/eea/dataset/io/notification/events/ReleaseValidationBlockersFailEventTest.java
+++ b/dataset-service/src/test/java/org/eea/dataset/io/notification/events/ReleaseValidationBlockersFailEventTest.java
@@ -1,6 +1,7 @@
 package org.eea.dataset.io.notification.events;
 
 import org.eea.dataset.service.DatasetService;
+import org.eea.dataset.service.ReleaseEmailService;
 import org.eea.exception.EEAException;
 import org.eea.kafka.domain.EventType;
 import org.eea.kafka.domain.NotificationVO;
@@ -28,7 +29,8 @@ public class ReleaseValidationBlockersFailEventTest {
   @Mock
   private DatasetService datasetService;
 
-
+  @Mock
+  private ReleaseEmailService releaseEmailService;
 
   /**
    * Inits the mocks.

--- a/orchestrator-service/src/main/java/org/eea/orchestrator/io/notification/events/ReleaseCanceledEvent.java
+++ b/orchestrator-service/src/main/java/org/eea/orchestrator/io/notification/events/ReleaseCanceledEvent.java
@@ -9,6 +9,7 @@ import org.eea.interfaces.vo.dataflow.DataProviderVO;
 import org.eea.kafka.domain.EventType;
 import org.eea.kafka.domain.NotificationVO;
 import org.eea.notification.event.NotificableEventHandler;
+import org.eea.orchestrator.service.ReleaseEmailService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -31,6 +32,9 @@ public class ReleaseCanceledEvent implements NotificableEventHandler {
 
   @Autowired
   private DatasetSnapshotController datasetSnapshotController;
+
+  @Autowired
+  private ReleaseEmailService releaseEmailService;
 
   /**
    * Gets the event type.
@@ -56,9 +60,13 @@ public class ReleaseCanceledEvent implements NotificableEventHandler {
     String dataProviderLabel = "";
     if (null != notificationVO.getProviderId()) {
       DataProviderVO dataProviderVO =
-              representativeControllerZuul.findDataProviderById(notificationVO.getProviderId());
+          representativeControllerZuul.findDataProviderById(notificationVO.getProviderId());
       dataProviderLabel = dataProviderVO.getLabel();
     }
+
+    // Send the notification error message to ReleaseEmailService so it can be included the failure email.
+    releaseEmailService.sendReleaseFailedEmail(notificationVO.getDataflowId(), notificationVO.getProviderId(), notificationVO.getError());
+
     Map<String, Object> notification = new HashMap<>();
     notification.put("user", notificationVO.getUser());
     notification.put("dataflowId", notificationVO.getDataflowId());

--- a/orchestrator-service/src/main/java/org/eea/orchestrator/io/notification/events/ReleaseRefusedEvent.java
+++ b/orchestrator-service/src/main/java/org/eea/orchestrator/io/notification/events/ReleaseRefusedEvent.java
@@ -1,5 +1,6 @@
 package org.eea.orchestrator.io.notification.events;
 
+import org.eea.orchestrator.service.ReleaseEmailService;
 import org.eea.exception.EEAException;
 import org.eea.interfaces.controller.dataflow.DataFlowController.DataFlowControllerZuul;
 import org.eea.interfaces.controller.dataflow.RepresentativeController.RepresentativeControllerZuul;
@@ -21,10 +22,12 @@ public class ReleaseRefusedEvent implements NotificableEventHandler {
     @Autowired
     private RepresentativeControllerZuul representativeControllerZuul;
 
-
     /** The dataflow controller zuul. */
     @Autowired
     private DataFlowControllerZuul dataFlowControllerZuul;
+
+    @Autowired
+    private ReleaseEmailService releaseEmailService;
 
     /**
      * Gets the event type.
@@ -53,9 +56,12 @@ public class ReleaseRefusedEvent implements NotificableEventHandler {
         String dataProviderLabel = "";
         if (null != providerId) {
             DataProviderVO dataProviderVO =
-                    representativeControllerZuul.findDataProviderById(notificationVO.getProviderId());
+                representativeControllerZuul.findDataProviderById(notificationVO.getProviderId());
             dataProviderLabel = dataProviderVO.getLabel();
         }
+
+        // Send the notification error message to ReleaseEmailService so it can be included the failure email.
+        releaseEmailService.sendReleaseFailedEmail(dataflowId, providerId, notificationVO.getError());
 
         Map<String, Object> notification = new HashMap<>();
         notification.put("user", notificationVO.getUser());

--- a/orchestrator-service/src/main/java/org/eea/orchestrator/io/notification/events/ReleaseValidationBlockersFailEvent.java
+++ b/orchestrator-service/src/main/java/org/eea/orchestrator/io/notification/events/ReleaseValidationBlockersFailEvent.java
@@ -1,5 +1,6 @@
 package org.eea.orchestrator.io.notification.events;
 
+import org.eea.orchestrator.service.ReleaseEmailService;
 import org.eea.exception.EEAException;
 import org.eea.interfaces.controller.dataset.DatasetController.DataSetControllerZuul;
 import org.eea.kafka.domain.EventType;
@@ -20,6 +21,9 @@ public class ReleaseValidationBlockersFailEvent implements NotificableEventHandl
 
   @Autowired
   private DataSetControllerZuul datasetService;
+
+  @Autowired
+  private ReleaseEmailService releaseEmailService;
 
   /**
    * Gets the event type.
@@ -42,6 +46,9 @@ public class ReleaseValidationBlockersFailEvent implements NotificableEventHandl
   public Map<String, Object> getMap(NotificationVO notificationVO) throws EEAException {
     Long dataflowId = notificationVO.getDataflowId() != null ? notificationVO.getDataflowId()
         : datasetService.getDataFlowIdById(notificationVO.getDatasetId());
+
+    // Send the notification error message to ReleaseEmailService so it can be included the failure email.
+    releaseEmailService.sendReleaseFailedEmail(dataflowId, notificationVO.getProviderId(), notificationVO.getError());
 
     Map<String, Object> notification = new HashMap<>();
     notification.put("user", notificationVO.getUser());

--- a/orchestrator-service/src/main/java/org/eea/orchestrator/service/ReleaseEmailService.java
+++ b/orchestrator-service/src/main/java/org/eea/orchestrator/service/ReleaseEmailService.java
@@ -1,0 +1,15 @@
+package org.eea.orchestrator.service;
+
+public interface ReleaseEmailService {
+
+  /**
+   * Sends the email notification when a release has started.
+   *
+   * @param dataflowId the dataflow id
+   * @param providerId the provider id
+   * @param reason the reason message
+   */
+  void sendReleaseFailedEmail(Long dataflowId, Long providerId, String reason);
+}
+
+

--- a/orchestrator-service/src/main/java/org/eea/orchestrator/service/impl/ReleaseEmailServiceImpl.java
+++ b/orchestrator-service/src/main/java/org/eea/orchestrator/service/impl/ReleaseEmailServiceImpl.java
@@ -1,0 +1,75 @@
+package org.eea.orchestrator.service.impl;
+
+import org.eea.interfaces.controller.dataflow.RepresentativeController.RepresentativeControllerZuul;
+import org.eea.interfaces.vo.dataflow.DataProviderVO;
+import org.eea.orchestrator.service.ReleaseEmailService;
+import org.eea.interfaces.controller.communication.EmailController.EmailControllerZuul;
+import org.eea.interfaces.controller.dataflow.DataFlowController.DataFlowControllerZuul;
+import org.eea.interfaces.controller.ums.UserManagementController.UserManagementControllerZull;
+import org.eea.interfaces.vo.communication.EmailVO;
+import org.eea.interfaces.vo.dataflow.DataFlowVO;
+import org.eea.interfaces.vo.ums.UserRepresentationVO;
+import org.eea.interfaces.vo.ums.enums.ResourceGroupEnum;
+import org.eea.utils.LiteralConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class ReleaseEmailServiceImpl implements ReleaseEmailService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ReleaseEmailServiceImpl.class);
+
+  @Autowired
+  private EmailControllerZuul emailControllerZuul;
+
+  @Autowired
+  private UserManagementControllerZull userManagementControllerZuul;
+
+  @Autowired
+  private DataFlowControllerZuul dataFlowControllerZuul;
+
+  @Autowired
+  private RepresentativeControllerZuul representativeControllerZuul;
+
+  @Override
+  public void sendReleaseFailedEmail(Long dataflowId, Long providerId, String reason) {
+    try {
+      DataFlowVO dataflowVO = dataFlowControllerZuul.getMetabaseById(dataflowId);
+
+      String providerName = "";
+      if (providerId != null) {
+        DataProviderVO provider = representativeControllerZuul.findDataProviderById(providerId);
+        providerName = provider.getLabel();
+      }
+
+      String date = ZonedDateTime.now(ZoneId.of(LiteralConstants.EUROPE_ZONE_ID))
+          .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+      List<UserRepresentationVO> custodians = userManagementControllerZuul.getUsersByGroup(
+          ResourceGroupEnum.DATAFLOW_CUSTODIAN.getGroupName(dataflowId));
+      List<String> emails = new ArrayList<>();
+
+      if (custodians != null) {
+        custodians.forEach(custodian -> emails.add(custodian.getEmail()));
+      }
+
+      EmailVO emailVO = new EmailVO();
+      emailVO.setBbc(emails);
+      emailVO.setSubject(String.format(LiteralConstants.RELEASE_FAILED_SUBJECT, providerName, dataflowVO.getName()));
+      emailVO.setText(String.format(LiteralConstants.RELEASE_FAILED_MESSAGE, providerName, dataflowVO.getName(), date, reason));
+      emailControllerZuul.sendMessage(emailVO);
+    } catch (Exception e) {
+      LOG.error("Unexpected error! Error sending release failed mail for dataflowId {}. Message: {}",
+          dataflowId, e.getMessage());
+    }
+  }
+
+}
+

--- a/recordstore-service/src/main/java/org/eea/recordstore/io/notification/event/ReleaseDatasetSnapshotFailedEvent.java
+++ b/recordstore-service/src/main/java/org/eea/recordstore/io/notification/event/ReleaseDatasetSnapshotFailedEvent.java
@@ -8,6 +8,7 @@ import org.eea.interfaces.controller.dataset.DatasetSnapshotController;
 import org.eea.kafka.domain.EventType;
 import org.eea.kafka.domain.NotificationVO;
 import org.eea.notification.event.NotificableEventHandler;
+import org.eea.recordstore.service.ReleaseEmailService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -25,6 +26,9 @@ public class ReleaseDatasetSnapshotFailedEvent implements NotificableEventHandle
 
   @Autowired
   private DatasetSnapshotController datasetSnapshotController;
+
+  @Autowired
+  private ReleaseEmailService releaseEmailService;
 
   /**
    * Gets the event type.
@@ -54,6 +58,9 @@ public class ReleaseDatasetSnapshotFailedEvent implements NotificableEventHandle
     notification.put("snapshotId", snapshotId);
     notification.put("snapshotName", datasetName);
     notification.put("error", notificationVO.getError());
+
+    // Send the notification error message to ReleaseEmailService so it can be included the failure email.
+    releaseEmailService.sendReleaseFailedEmail(notificationVO.getDataflowId(), notificationVO.getProviderId(), notificationVO.getError());
 
     datasetSnapshotController.rollBackSnapshotRecord(notificationVO.getJobId(), notificationVO.getDataflowId(), notificationVO.getProviderId());
 

--- a/recordstore-service/src/main/java/org/eea/recordstore/service/ReleaseEmailService.java
+++ b/recordstore-service/src/main/java/org/eea/recordstore/service/ReleaseEmailService.java
@@ -1,0 +1,15 @@
+package org.eea.recordstore.service;
+
+public interface ReleaseEmailService {
+
+  /**
+   * Sends the email notification when a release has started.
+   *
+   * @param dataflowId the dataflow id
+   * @param providerId the provider id
+   * @param reason the reason message
+   */
+  void sendReleaseFailedEmail(Long dataflowId, Long providerId, String reason);
+}
+
+

--- a/recordstore-service/src/main/java/org/eea/recordstore/service/impl/ReleaseEmailServiceImpl.java
+++ b/recordstore-service/src/main/java/org/eea/recordstore/service/impl/ReleaseEmailServiceImpl.java
@@ -1,0 +1,75 @@
+package org.eea.recordstore.service.impl;
+
+import org.eea.interfaces.controller.communication.EmailController.EmailControllerZuul;
+import org.eea.interfaces.controller.dataflow.DataFlowController.DataFlowControllerZuul;
+import org.eea.interfaces.controller.dataflow.RepresentativeController.RepresentativeControllerZuul;
+import org.eea.interfaces.controller.ums.UserManagementController.UserManagementControllerZull;
+import org.eea.interfaces.vo.communication.EmailVO;
+import org.eea.interfaces.vo.dataflow.DataFlowVO;
+import org.eea.interfaces.vo.dataflow.DataProviderVO;
+import org.eea.interfaces.vo.ums.UserRepresentationVO;
+import org.eea.interfaces.vo.ums.enums.ResourceGroupEnum;
+import org.eea.recordstore.service.ReleaseEmailService;
+import org.eea.utils.LiteralConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class ReleaseEmailServiceImpl implements ReleaseEmailService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ReleaseEmailServiceImpl.class);
+
+  @Autowired
+  private EmailControllerZuul emailControllerZuul;
+
+  @Autowired
+  private UserManagementControllerZull userManagementControllerZuul;
+
+  @Autowired
+  private DataFlowControllerZuul dataFlowControllerZuul;
+
+  @Autowired
+  private RepresentativeControllerZuul representativeControllerZuul;
+
+  @Override
+  public void sendReleaseFailedEmail(Long dataflowId, Long providerId, String reason) {
+    try {
+      DataFlowVO dataflowVO = dataFlowControllerZuul.getMetabaseById(dataflowId);
+
+      String providerName = "";
+      if (providerId != null) {
+        DataProviderVO provider = representativeControllerZuul.findDataProviderById(providerId);
+        providerName = provider.getLabel();
+      }
+
+      String date = ZonedDateTime.now(ZoneId.of(LiteralConstants.EUROPE_ZONE_ID))
+          .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+      List<UserRepresentationVO> custodians = userManagementControllerZuul.getUsersByGroup(
+          ResourceGroupEnum.DATAFLOW_CUSTODIAN.getGroupName(dataflowId));
+      List<String> emails = new ArrayList<>();
+
+      if (custodians != null) {
+        custodians.forEach(custodian -> emails.add(custodian.getEmail()));
+      }
+
+      EmailVO emailVO = new EmailVO();
+      emailVO.setBbc(emails);
+      emailVO.setSubject(String.format(LiteralConstants.RELEASE_FAILED_SUBJECT, providerName, dataflowVO.getName()));
+      emailVO.setText(String.format(LiteralConstants.RELEASE_FAILED_MESSAGE, providerName, dataflowVO.getName(), date, reason));
+      emailControllerZuul.sendMessage(emailVO);
+    } catch (Exception e) {
+      LOG.error("Unexpected error! Error sending release failed mail for dataflowId {}. Message: {}",
+          dataflowId, e.getMessage());
+    }
+  }
+
+}
+

--- a/recordstore-service/src/test/java/org/eea/recordstore/io/notification/event/ReleaseDatasetSnapshotFailedEventTest.java
+++ b/recordstore-service/src/test/java/org/eea/recordstore/io/notification/event/ReleaseDatasetSnapshotFailedEventTest.java
@@ -6,6 +6,7 @@ import org.eea.interfaces.controller.dataset.DatasetSnapshotController;
 import org.eea.interfaces.vo.dataset.DataSetMetabaseVO;
 import org.eea.kafka.domain.EventType;
 import org.eea.kafka.domain.NotificationVO;
+import org.eea.recordstore.service.ReleaseEmailService;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,7 +30,8 @@ public class ReleaseDatasetSnapshotFailedEventTest {
   @Mock
   private DatasetSnapshotController datasetSnapshotController;
 
-
+  @Mock
+  private ReleaseEmailService releaseEmailService;
 
   @Before
   public void initMocks() {


### PR DESCRIPTION
This feature is the implementation for the **NEW RELEASE FLOW** that exists currently only on TestEnv.
The same service was implemented for dataset,orchestrator,recordstore services to follow the pattern we have with the event handlers.

**Emails send per service and the event handlers they own:**
| HANDLER | PURPOSE | SERVICE |
|---|---|---|
| ReleasePrecheckService | START | dataset |
| ReleaseDataSnapshotsCommand | FINISH | dataset |
| ReleaseDatasetSnapshotFailedEvent | FAILURE | dataset |
| ReleaseFailedDatasetLockedForEditingExistsEvent | FAILURE | dataset |
| ReleaseFailedIcebergExistsEvent | FAILURE | dataset |
| ReleaseRefusedEvent | FAILURE | dataset |
| ReleaseValidationBlockersFailEvent | FAILURE | dataset |
| ReleaseValidationBlockersFailEvent | FAILURE | orchestrator |
| ReleaseCanceledEvent | FAILURE | orchestrator |
| ReleaseRefusedEvent | FAILURE | orchestrator |
| ReleaseDatasetSnapshotFailedEvent | FAILURE | recordstore |
| ReleaseDatasetSnapshotFailedEvent | FAILURE | recordstore |

Each Event Handler is responsible for it's own failure email initialization by calling:
`releaseEmailService.sendReleaseFailedEmail(dataflowId, providerId, notificationVO.getError());`

**In LiteraConstants, the new subject and message enums for START/FAILURE emails were added:**
- RELEASE_STARTED_SUBJECT = "%s started a release for %s";
- RELEASE_STARTED_MESSAGE = "This automatic notification informs that %s started the release process for dataflow %s on %s (CET).";
- RELEASE_FAILED_SUBJECT = "%s failed to release for %s";
- RELEASE_FAILED_MESSAGE = "This automatic notification informs that %s failed to release for dataflow %s on %s (CET). Reason: %s";
